### PR TITLE
Fix workflow encoding for timestamp automation

### DIFF
--- a/.github/workflows/ots-append.yml
+++ b/.github/workflows/ots-append.yml
@@ -1,4 +1,4 @@
-﻿name: ots-append
+name: ots-append
 on:
   push:
     paths:

--- a/.github/workflows/ots-stamp-letter-asc.yml
+++ b/.github/workflows/ots-stamp-letter-asc.yml
@@ -1,4 +1,4 @@
-﻿name: ots-stamp-letter-asc
+name: ots-stamp-letter-asc
 on:
   push:
     paths:

--- a/.github/workflows/ots-upgrade.yml
+++ b/.github/workflows/ots-upgrade.yml
@@ -38,16 +38,16 @@ jobs:
 
           HEIGHT=""
           if [[ -n "$TARGET" ]]; then
-  echo "Using TARGET='$TARGET'"# Only stamp if proof file doesn't exist
+            echo "Using TARGET='$TARGET'"
             if [ ! -f "${TARGET}.ots" ]; then
-              echo "No .ots present — stamping…"
+              echo "No .ots present; stamping"
               ots stamp "$TARGET"
             else
-              echo "Found ${TARGET}.ots — skipping stamp."
+              echo "Found ${TARGET}.ots; skipping stamp."
             fi
             # Always attempt to upgrade; ignore 'nothing to do' errors
             ots upgrade "${TARGET}.ots" || true
-            mv "${TARGET}.ots" /tmp/proof.ots
+            cp "${TARGET}.ots" /tmp/proof.ots
             ots upgrade /tmp/proof.ots || true
 
             set +e

--- a/.github/workflows/ots-verify-upgrade.yml
+++ b/.github/workflows/ots-verify-upgrade.yml
@@ -1,4 +1,4 @@
-﻿name: ots-verify-upgrade
+name: ots-verify-upgrade
 on:
   workflow_dispatch:
 

--- a/.github/workflows/releases-manifest.yml
+++ b/.github/workflows/releases-manifest.yml
@@ -1,4 +1,4 @@
-﻿name: releases-manifest
+name: releases-manifest
 on:
   push:
     paths:

--- a/.github/workflows/sync-readme-fingerprint.yml
+++ b/.github/workflows/sync-readme-fingerprint.yml
@@ -1,4 +1,4 @@
-﻿name: sync-readme-fingerprint
+name: sync-readme-fingerprint
 on:
   push:
     paths:

--- a/.github/workflows/verify-releases.yml
+++ b/.github/workflows/verify-releases.yml
@@ -1,4 +1,4 @@
-﻿name: Verify OpenPGP clear-signed releases
+name: Verify OpenPGP clear-signed releases
 on: [push, pull_request]
 jobs:
   verify:


### PR DESCRIPTION
## Summary
- remove stray BOM bytes from the GitHub Actions workflows so they parse correctly
- clean up the ots-upgrade job logging to keep the proof file in place while updating footer text

## Testing
- not run (workflow-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68c927c13ca08330b492946e568062a2