### PR TITLE
Fix ots-upgrade workflow YAML syntax failure

### DIFF
--- a/.github/scripts/extract_block_height.py
+++ b/.github/scripts/extract_block_height.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Extract the highest Bitcoin block height from an OpenTimestamps proof."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+try:
+    from opentimestamps.core.serialize import StreamDeserializationContext
+    from opentimestamps.core.timestamp import DetachedTimestampFile
+    from opentimestamps.core.notary import BitcoinBlockHeaderAttestation
+except Exception:
+    sys.exit(0)
+
+
+def main(path_arg: str) -> None:
+    path = Path(path_arg)
+    if not path.is_file():
+        return
+
+    try:
+        with path.open('rb') as fh:
+            ctx = StreamDeserializationContext(fh)
+            timestamp = DetachedTimestampFile.deserialize(ctx).timestamp
+    except Exception:
+        return
+
+    heights = sorted(
+        {
+            att.height
+            for _, att in timestamp.all_attestations()
+            if isinstance(att, BitcoinBlockHeaderAttestation)
+        }
+    )
+    if heights:
+        print(heights[-1])
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        sys.exit(0)
+    main(sys.argv[1])

--- a/.github/workflows/ots-upgrade.yml
+++ b/.github/workflows/ots-upgrade.yml
@@ -50,33 +50,7 @@ jobs:
             cp "${TARGET}.ots" /tmp/proof.ots
             ots upgrade /tmp/proof.ots || true
 
-            if PY_OUT="$(python - /tmp/proof.ots <<'PY'
-import sys
-from pathlib import Path
-try:
-    from opentimestamps.core.serialize import StreamDeserializationContext
-    from opentimestamps.core.timestamp import DetachedTimestampFile
-    from opentimestamps.core.notary import BitcoinBlockHeaderAttestation
-except Exception:
-    sys.exit(0)
-
-path = Path(sys.argv[1])
-if not path.is_file():
-    sys.exit(0)
-
-try:
-    with path.open('rb') as fh:
-        ctx = StreamDeserializationContext(fh)
-        timestamp = DetachedTimestampFile.deserialize(ctx).timestamp
-except Exception:
-    sys.exit(0)
-
-heights = sorted({att.height for _, att in timestamp.all_attestations()
-                  if isinstance(att, BitcoinBlockHeaderAttestation)})
-if heights:
-    print(heights[-1])
-PY
-)"; then
+            if PY_OUT="$(python .github/scripts/extract_block_height.py /tmp/proof.ots)"; then
               HEIGHT="${PY_OUT//$'\n'/}"
               HEIGHT="${HEIGHT//$'\r'/}"
             fi


### PR DESCRIPTION
## Summary
- replace the inline heredoc in the ots-upgrade workflow with a call to a helper script so the YAML parses
- add `.github/scripts/extract_block_height.py` to extract the newest Bitcoin block height from an OpenTimestamps proof

## Testing
- python -m compileall .github/scripts/extract_block_height.py

------
https://chatgpt.com/codex/tasks/task_e_68c9e8ebf3c883308d0313ced1383d62