### PR TITLE
Fix ots verify upgrade workflow to use CLI

### DIFF
--- a/.github/workflows/ots-verify-upgrade.yml
+++ b/.github/workflows/ots-verify-upgrade.yml
@@ -15,26 +15,28 @@ jobs:
         with:
           python-version: '3.x'
 
-      - run: python -m pip install --upgrade pip opentimestamps-client
+      - run: |
+          python -m pip install --upgrade pip opentimestamps-client
+          echo "$(python -c 'import sysconfig; print(sysconfig.get_path("scripts"))')" >> "$GITHUB_PATH"
 
       - name: Show OTS info/verify (before)
         run: |
           set -e
           echo "::group::info"
-          python -m opentimestamps.client info letter/ASI-Letter-v2025.09.14.md.asc.ots || true
+          ots info letter/ASI-Letter-v2025.09.14.md.asc.ots || true
           echo "::endgroup::"
           echo "::group::verify (before)"
-          python -m opentimestamps.client verify letter/ASI-Letter-v2025.09.14.md.asc.ots || true
+          ots verify letter/ASI-Letter-v2025.09.14.md.asc.ots || true
           echo "::endgroup::"
 
       - name: Upgrade proof
         run: |
-          python -m opentimestamps.client upgrade letter/ASI-Letter-v2025.09.14.md.asc.ots || true
+          ots upgrade letter/ASI-Letter-v2025.09.14.md.asc.ots || true
 
       - name: Show verify (after)
         run: |
           echo "::group::verify (after)"
-          python -m opentimestamps.client verify letter/ASI-Letter-v2025.09.14.md.asc.ots || true
+          ots verify letter/ASI-Letter-v2025.09.14.md.asc.ots || true
           echo "::endgroup::"
 
       - name: Commit upgraded proof if changed


### PR DESCRIPTION
## Summary
- ensure the workflow exposes the Python scripts directory after installing opentimestamps-client
- swap the verification and upgrade steps to use the `ots` CLI instead of a missing Python module

## Testing
- /root/.pyenv/versions/3.11.12/bin/ots info letter/ASI-Letter-v2025.09.14.md.asc.ots


------
https://chatgpt.com/codex/tasks/task_e_68c9fb35f4c48330a038b9747cc671ac