### PR TITLE
Fix YAML indentation in ots-append workflow

### DIFF
--- a/.github/workflows/ots-append.yml
+++ b/.github/workflows/ots-append.yml
@@ -66,14 +66,14 @@ jobs:
 
           STATUS="${STATUS_LINE:-Bitcoin anchoring pending. Proof will update automatically.}"
 
-          cat >> "$HTML" <<EOF
-<!-- OTS-START -->
-<section id="timestamp-proof" style="max-width:48rem;margin:2rem auto 0 auto;padding-top:1rem;border-top:1px solid #e5e7eb;text-align:center;font-size:0.95rem;line-height:1.5;">
-  <h3 style="margin:0 0 .5rem 0;font-size:1.05rem;">Timestamp proof (Bitcoin)</h3>
-  <p id="ots-line">${STATUS}</p>
-</section>
-<!-- OTS-END -->
-EOF
+          {
+            printf '%s\n' '<!-- OTS-START -->'
+            printf '%s\n' '<section id="timestamp-proof" style="max-width:48rem;margin:2rem auto 0 auto;padding-top:1rem;border-top:1px solid #e5e7eb;text-align:center;font-size:0.95rem;line-height:1.5;">'
+            printf '%s\n' '  <h3 style="margin:0 0 .5rem 0;font-size:1.05rem;">Timestamp proof (Bitcoin)</h3>'
+            printf '  <p id="ots-line">%s</p>\n' "${STATUS}"
+            printf '%s\n' '</section>'
+            printf '%s\n' '<!-- OTS-END -->'
+          } >> "$HTML"
 
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:


### PR DESCRIPTION
## Summary
- replace the heredoc in the ots-append workflow with printf statements so every shell line stays properly indented for YAML
- keep the rendered HTML footer identical while avoiding YAML syntax errors

## Testing
- not run (workflow syntax fix)


------
https://chatgpt.com/codex/tasks/task_e_68ca025f39a08330a5b6c58f056ec119