### PR TITLE
Add tested helper for selecting latest OTS proof

### DIFF
--- a/.github/workflows/ots-verify-upgrade.yml
+++ b/.github/workflows/ots-verify-upgrade.yml
@@ -19,28 +19,34 @@ jobs:
           python -m pip install --upgrade pip opentimestamps-client
           echo "$(python -c 'import sysconfig; print(sysconfig.get_path("scripts"))')" >> "$GITHUB_PATH"
 
+      - name: Determine latest OTS proof
+        id: latest-ots
+        run: |
+          set -eo pipefail
+          python scripts/find_latest_ots.py letter >> "$GITHUB_OUTPUT"
+
       - name: Show OTS info/verify (before)
         run: |
           set -e
           echo "::group::info"
-          ots info letter/ASI-Letter-v2025.09.14.md.asc.ots || true
+          ots info "${{ steps.latest-ots.outputs.latest }}" || true
           echo "::endgroup::"
           echo "::group::verify (before)"
-          ots verify letter/ASI-Letter-v2025.09.14.md.asc.ots || true
+          ots verify "${{ steps.latest-ots.outputs.latest }}" || true
           echo "::endgroup::"
 
       - name: Upgrade proof
         run: |
-          ots upgrade letter/ASI-Letter-v2025.09.14.md.asc.ots || true
+          ots upgrade "${{ steps.latest-ots.outputs.latest }}" || true
 
       - name: Show verify (after)
         run: |
           echo "::group::verify (after)"
-          ots verify letter/ASI-Letter-v2025.09.14.md.asc.ots || true
+          ots verify "${{ steps.latest-ots.outputs.latest }}" || true
           echo "::endgroup::"
 
       - name: Commit upgraded proof if changed
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: "chore(ots): upgrade ASI-Letter-v2025.09.14 proof"
-          file_pattern: "letter/ASI-Letter-v2025.09.14.md.asc.ots"
+          commit_message: "chore(ots): upgrade ${{ steps.latest-ots.outputs.version }} proof"
+          file_pattern: "letter/${{ steps.latest-ots.outputs.basename }}"

--- a/scripts/find_latest_ots.py
+++ b/scripts/find_latest_ots.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Utilities for locating the newest OpenTimestamps proof in a directory."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List
+
+
+@dataclass(frozen=True)
+class LatestOts:
+    """Details about the newest OpenTimestamps proof discovered."""
+
+    path: Path
+    basename: str
+    noext: str
+    version: str
+
+
+def _candidate_files(directory: Path) -> Iterable[Path]:
+    for entry in directory.iterdir():
+        if entry.is_file() and entry.suffix == ".ots":
+            yield entry
+
+
+def _sort_key(path: Path) -> tuple[float, str]:
+    stat = path.stat()
+    return stat.st_mtime, path.name
+
+
+def _derive_version_components(path: Path) -> tuple[str, str, str]:
+    basename = path.name
+    noext = basename[: -len(path.suffix)] if path.suffix else basename
+    version = noext
+    if noext.endswith(".md.asc"):
+        version = noext[: -len(".md.asc")]
+    return basename, noext, version
+
+
+def find_latest_ots(directory: Path) -> LatestOts:
+    """Return information about the newest ``.ots`` file in *directory*.
+
+    Parameters
+    ----------
+    directory:
+        Directory that will be searched. Only files directly inside this
+        directory (i.e. depth 1) are considered.
+    """
+
+    if not directory.is_dir():
+        raise FileNotFoundError(f"{directory} is not a directory")
+
+    candidates: List[Path] = list(_candidate_files(directory))
+    if not candidates:
+        raise FileNotFoundError("No .ots files found in directory")
+
+    latest = max(candidates, key=_sort_key)
+    basename, noext, version = _derive_version_components(latest)
+    return LatestOts(path=latest.resolve(), basename=basename, noext=noext, version=version)
+
+
+def _format_outputs(latest: LatestOts, *, base_dir: Path | None = None) -> List[str]:
+    cwd = base_dir or Path.cwd()
+    try:
+        rel_path = latest.path.relative_to(cwd)
+    except ValueError:
+        rel_path = Path(os.path.relpath(latest.path, cwd))
+
+    return [
+        f"latest={rel_path.as_posix()}",
+        f"basename={latest.basename}",
+        f"noext={latest.noext}",
+        f"version={latest.version}",
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "directory",
+        type=Path,
+        nargs="?",
+        default=Path("letter"),
+        help="Directory containing .ots files (default: letter)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        latest = find_latest_ots(args.directory)
+    except FileNotFoundError as exc:
+        print(str(exc), file=os.sys.stderr)
+        return 1
+
+    for line in _format_outputs(latest):
+        print(line)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_find_latest_ots.py
+++ b/tests/test_find_latest_ots.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import os
+import time
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from scripts.find_latest_ots import find_latest_ots, _format_outputs
+
+
+class FindLatestOtsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.tmp_path = Path(self.tmp.name)
+
+    def create_file(self, name: str, *, mtime: float | None = None) -> Path:
+        path = self.tmp_path / name
+        path.write_text("sample")
+        ts = mtime if mtime is not None else time.time()
+        os.utime(path, (ts, ts))
+        return path
+
+    def test_selects_newest_file_by_mtime(self) -> None:
+        base_time = 1_700_000_000
+        files = [
+            self.create_file("letter-old.ots", mtime=base_time),
+            self.create_file("letter-newer.ots", mtime=base_time + 10),
+            self.create_file("letter-newest.ots", mtime=base_time + 20),
+        ]
+
+        latest = find_latest_ots(self.tmp_path)
+        self.assertEqual(latest.basename, files[-1].name)
+
+    def test_version_extraction_cases(self) -> None:
+        base_time = 1_700_100_000
+        cases = [
+            ("alpha.md.asc.ots", "alpha.md.asc", "alpha"),
+            ("beta.md.ots", "beta.md", "beta.md"),
+            ("gamma.asc.ots", "gamma.asc", "gamma.asc"),
+            ("delta.ots", "delta", "delta"),
+        ]
+
+        created = {name: self.create_file(name, mtime=base_time + idx) for idx, (name, _, _) in enumerate(cases)}
+
+        for idx, (name, expected_noext, expected_version) in enumerate(cases, start=1):
+            # bump the mtime to ensure this file is selected as the newest
+            mtime = base_time + len(cases) + idx
+            path = created[name]
+            os.utime(path, (mtime, mtime))
+
+            latest = find_latest_ots(self.tmp_path)
+            self.assertEqual(latest.basename, name)
+            self.assertEqual(latest.noext, expected_noext)
+            self.assertEqual(latest.version, expected_version)
+
+    def test_format_outputs_relative_path(self) -> None:
+        path = self.create_file("epsilon.ots")
+        latest = find_latest_ots(self.tmp_path)
+        outputs = _format_outputs(latest, base_dir=self.tmp_path)
+        expected_prefix = f"latest={path.name}"
+        self.assertTrue(outputs[0].startswith(expected_prefix))
+
+    def test_raises_when_directory_missing(self) -> None:
+        with self.assertRaises(FileNotFoundError):
+            find_latest_ots(self.tmp_path / "missing")
+
+    def test_raises_when_no_ots_present(self) -> None:
+        empty_dir = self.tmp_path / "empty"
+        empty_dir.mkdir()
+        with self.assertRaises(FileNotFoundError):
+            find_latest_ots(empty_dir)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- replace the workflow discovery step with a Python helper that reports the newest proof
- add a script and unit tests covering the different .ots filename variants so the workflow uses the latest file

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68ca04e93e2883308478f39c7c3c6743