### PR TITLE
fix: prevent redundant pages reruns after ots refresh

### DIFF
--- a/.github/workflows/ots-upgrade.yml
+++ b/.github/workflows/ots-upgrade.yml
@@ -82,7 +82,7 @@ jobs:
                 gsub(/<p id="ots-line">.*<\/p>/,
                      "<p id=\"ots-line\">Bitcoin anchoring pending. Proof will update automatically.</p>", $0);
               }
-              print
+              printf "%s\n", $0
             }' "$HTML" > "$HTML.tmp"
           mv "$HTML.tmp" "$HTML"
 


### PR DESCRIPTION
## Summary
- ensure the ots-upgrade workflow preserves a trailing newline when rewriting docs/index.html
- this keeps the follow-up ots-append workflow from committing a cosmetic newline-only change that was cancelling the in-flight Pages deployment

## Testing
- not run (workflow logic change only)

------
https://chatgpt.com/codex/tasks/task_e_68ca28825f3083308bc7c94a4bb4ff5f