### PR TITLE
ci: serialize workflows that auto-commit artifacts

### DIFF
--- a/.github/workflows/ots-append.yml
+++ b/.github/workflows/ots-append.yml
@@ -11,6 +11,10 @@ on:
       - completed
   workflow_dispatch: {}
 
+concurrency:
+  group: letter-artifacts-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
 

--- a/.github/workflows/ots-stamp-letter-asc.yml
+++ b/.github/workflows/ots-stamp-letter-asc.yml
@@ -5,6 +5,10 @@ on:
       - 'letter/*.asc'
   workflow_dispatch: {}
 
+concurrency:
+  group: letter-artifacts-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
 

--- a/.github/workflows/ots-upgrade.yml
+++ b/.github/workflows/ots-upgrade.yml
@@ -4,6 +4,10 @@ on:
     - cron: "23 * * * *"
   workflow_dispatch: {}
 
+concurrency:
+  group: letter-artifacts-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
 

--- a/.github/workflows/ots-verify-upgrade.yml
+++ b/.github/workflows/ots-verify-upgrade.yml
@@ -2,6 +2,10 @@ name: ots-verify-upgrade
 on:
   workflow_dispatch:
 
+concurrency:
+  group: letter-artifacts-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
 

--- a/.github/workflows/releases-manifest.yml
+++ b/.github/workflows/releases-manifest.yml
@@ -7,6 +7,10 @@ on:
       - "scripts/gen_releases_manifest.py"
   workflow_dispatch: {}
 
+concurrency:
+  group: letter-artifacts-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
 

--- a/.github/workflows/sync-readme-fingerprint.yml
+++ b/.github/workflows/sync-readme-fingerprint.yml
@@ -5,6 +5,10 @@ on:
       - "keys/FINGERPRINT"
   workflow_dispatch: {}
 
+concurrency:
+  group: letter-artifacts-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
 


### PR DESCRIPTION
## Summary
- add a shared concurrency group to the workflows that push generated artifacts so they queue instead of racing each other

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cabf3937448330b3b8d81e7f02834a