### PR TITLE
fix: prevent OTS stamping workflow push conflicts

### DIFF
--- a/.github/workflows/ots-stamp-letter-asc.yml
+++ b/.github/workflows/ots-stamp-letter-asc.yml
@@ -22,6 +22,7 @@ jobs:
         run: python -m pip install --upgrade opentimestamps-client
 
       - name: Stamp any new .asc in /letter (idempotent)
+        id: stamp
         shell: bash
         run: |
           set -euo pipefail
@@ -40,7 +41,17 @@ jobs:
           done
           echo "touched=$touched" >> "$GITHUB_OUTPUT"
 
+      - name: Rebase onto latest ${{ github.ref_name }} before pushing proofs
+        if: steps.stamp.outputs.touched == '1'
+        shell: bash
+        run: |
+          set -euo pipefail
+          branch="${GITHUB_REF##*/}"
+          git fetch origin "$branch"
+          git pull --rebase --autostash origin "$branch"
+
       - uses: stefanzweifel/git-auto-commit-action@v5
+        if: steps.stamp.outputs.touched == '1'
         with:
           commit_message: "chore(ots): add proofs for new /letter/*.asc [skip ci]"
           file_pattern: letter/*.asc.ots


### PR DESCRIPTION
## Summary
- expose the stamping step output so later steps can react to new proofs
- rebase onto the latest branch revision with autostash before committing stamped proofs
- only run the auto-commit step when new .asc.ots files were produced

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68caca5355e8833082cd4d247a75a636