### PR TITLE
Fix OTS automation skip logic and sync docs letter

### DIFF
--- a/.github/workflows/ots-append.yml
+++ b/.github/workflows/ots-append.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   append-proof:
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success') && (github.event_name != 'push' || !contains(github.event.head_commit.message || '', '[ots-append-auto]')) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -81,5 +81,5 @@ jobs:
 
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: "chore(ots): ensure footer + status [skip ci]"
+          commit_message: "chore(ots): ensure footer + status [ots-append-auto]"
           file_pattern: docs/index.html

--- a/.github/workflows/ots-stamp-letter-asc.yml
+++ b/.github/workflows/ots-stamp-letter-asc.yml
@@ -53,5 +53,5 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@v5
         if: steps.stamp.outputs.touched == '1'
         with:
-          commit_message: "chore(ots): add proofs for new /letter/*.asc [skip ci]"
+          commit_message: "chore(ots): add proofs for new /letter/*.asc (auto)"
           file_pattern: letter/*.asc.ots

--- a/.github/workflows/ots-upgrade.yml
+++ b/.github/workflows/ots-upgrade.yml
@@ -92,6 +92,6 @@ jobs:
 
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: "chore(ots): upgrade proof + refresh status [skip ci]"
+          commit_message: "chore(ots): upgrade proof + refresh status [ots-upgrade-auto]"
           file_pattern: docs/index.html
 

--- a/.github/workflows/releases-manifest.yml
+++ b/.github/workflows/releases-manifest.yml
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'push' || !contains(github.event.head_commit.message, '[manifest-auto]') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -24,7 +25,14 @@ jobs:
           python-version: "3.x"
       - name: Generate manifest (python)
         run: python3 scripts/gen_releases_manifest.py
+      - name: Sync docs with latest letter
+        run: python3 scripts/sync_docs_with_latest.py
+      - name: Update version metadata in docs
+        run: python3 scripts/update_version_metadata.py
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: "chore(manifest): update letter/RELEASES.json [skip ci]"
-          file_pattern: "letter/RELEASES.json"
+          commit_message: "chore(manifest): refresh release assets [manifest-auto]"
+          file_pattern: |
+            letter/RELEASES.json
+            docs/letter.md
+            docs/index.html

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,11 +1,11 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <!-- release-version: v2025.09.14 -->
+  <!-- release-version: v2025.09.17 -->
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="color-scheme" content="light dark">
-  <title>ASI Letter — v2025.09.14</title>
+  <title>ASI Letter — v2025.09.17</title>
   <style>
     :root{
       --w:900px; --pad-x:24px; --lh:1.7;
@@ -90,7 +90,7 @@
     .error{color:#b91c1c}
   </style>
 </head>
-<body data-release-version="v2025.09.14">
+<body data-release-version="v2025.09.17">
   <main class="container">
     <article class="markdown-body">
       <div id="md" class="loading">Loading letter…</div>      <!-- Hidden canonical signature; shown only if none detected -->

--- a/docs/letter.md
+++ b/docs/letter.md
@@ -120,21 +120,32 @@ To use a predictive model of *Alice-after* for dual-key consent, these condition
 
 ## Duress & incapacitation safeguards (Odysseus Pact)
 
-**Scope:** This clause temporarily limits actions when my agency appears compromised by coercion, acute impairment, or credible risk to self.
-**Triggers (evidence required):** verifiable signs of duress or impairment; significant deviation from an agreed cognitive baseline (to be established during stability); or cryptographically signed reports from a **Council of Friends** I designate in advance.
-**Council of Friends:** Named by me; their unanimous cryptographic attestation can place the system in **protective observation mode**. They may restrict, not compel, actions.
+**Scope:**
+This clause temporarily limits actions when my agency appears compromised by coercion, acute impairment, or credible risk to self.
+
+**Triggers (evidence required):**
+Verifiable signs of duress or impairment; significant deviation from an agreed cognitive baseline (to be established during stability); or cryptographically signed reports from a **Council of Friends** I designate in advance.
+
+**Council of Friends:**
+Named by me; their unanimous cryptographic attestation can place the system in **protective observation mode**. They may restrict, not compel, actions.
+
 **Council maintenance & contingencies:**
-– **Maintenance & updates:** I will review and update the Council roster and cryptographic keys periodically, or as needed. Any update requires my explicit, verified consent during a state of normal operation, with an auditable record.
-– **Key hygiene:** Compromised or lost keys are revoked and re-issued; the system must honor the latest attested key list.
-– **Availability fallback:** Unanimity is preferred. If unanimity is impossible after reasonable attempts to contact all members, the Council may act with **unanimous consent of all responsive members**, with a **minimum of two**, unless I have specified otherwise in writing.
-– **Replacement:** If a member becomes persistently unresponsive or withdraws, I may replace them during normal operation and publish an updated attestation.
-– **Scope of authority:** The Council may **restrict** (not compel) actions by placing the system in protective observation mode, as already defined.
+- **Maintenance & updates:** I will review and update the Council roster and cryptographic keys periodically, or as needed. Any update requires my explicit, verified consent during a state of normal operation, with an auditable record.
+- **Key hygiene:** Compromised or lost keys are revoked and re-issued; the system must honor the latest attested key list.
+- **Availability fallback:** Unanimity is preferred. If unanimity is impossible after reasonable attempts to contact all members, the Council may act with **unanimous consent of all responsive members**, with a **minimum of two**, unless I have specified otherwise in writing.
+- **Replacement:** If a member becomes persistently unresponsive or withdraws, I may replace them during normal operation and publish an updated attestation.
+- **Scope of authority:** The Council may **restrict** (not compel) actions by placing the system in protective observation mode, as already defined.
+
 **Protective observation mode:**
-– Decline new **irreversible or high-consequence** actions; perform only maintenance, safety, or routine tasks.
-– Keep **explanations on demand**, exhaustive logging, and frequent check-ins.
-– Default to **ask/pause** if intent is unclear.
-**Exit & review:** Time-bounded and reviewable; I can exit with a pre-agreed proof-of-health check or passphrase; the Council may lift it; all actions during this mode are auditable.
-**Sealed orders (optional):** I may provide sealed instructions to be opened only under these conditions; they cannot authorize violation of **dignity** or **consent**.
+- Decline new **irreversible or high-consequence** actions; perform only maintenance, safety, or routine tasks.
+- Keep **explanations on demand**, exhaustive logging, and frequent check-ins.
+- Default to **ask/pause** if intent is unclear.
+
+**Exit & review:**
+Time-bounded and reviewable; I can exit with a pre-agreed proof-of-health check or passphrase; the Council may lift it; all actions during this mode are auditable.
+
+**Sealed orders (optional):**
+I may provide sealed instructions to be opened only under these conditions; they cannot authorize violation of **dignity** or **consent**.
 
 - ---
 
@@ -167,6 +178,7 @@ With these principles established, here is the step-by-step way I prefer to proc
    Gradual augmentation—wearables, neural interfaces—favoring **reversibility** and **auditability**.
 
 5. **Continuity experiments (farther future):**
+
    Proceed only if the following hold:
 
    * **Dual-key consent:** explicit opt-in from *Alice-now* and a predictive model of *Alice-after* (both must concur).
@@ -174,12 +186,15 @@ With these principles established, here is the step-by-step way I prefer to proc
    * **Observation window & rollback:** for a defined period, if continuity feels degraded or alien, restore from pre-step snapshot; no stigma, no penalty.
    * **Constitutional lock-ins:** the axioms (dignity, consent, reversibility, non-coercion) are embedded as a read-only layer I can always invoke.
    * **Small steps:** iterate in **narrow, reversible** increments; no global, non-reversible jumps.
-     **Irreversibility protocol:** For actions deemed **irreversible**, apply heightened safeguards:
-     – **Dual-key consent + independent review:** in addition to *Alice-now* and *Alice-after*, consult a designated trusted human (from the Council) for a non-binding risk review.
-     – **Cooling-off & reconfirmation:** confirm consent across multiple distinct times/contexts; no single-sitting approvals.
-     – **Shadow runs & simulations:** run detailed simulations and **dry-runs** with rollback drills; document worst-case scenarios and mitigation.
-     – **Higher evidence threshold:** require stronger evidence for safety and continuity than for reversible steps.
-     – **No single-shot leaps:** decompose into the smallest viable increments; take the last irreversible step **only after** preceding steps demonstrate stability and felt continuity.
+
+   **Irreversibility protocol:**
+   For actions deemed **irreversible**, apply heightened safeguards:
+
+   - **Dual-key consent + independent review:** in addition to *Alice-now* and *Alice-after*, consult a designated trusted human (from the Council) for a non-binding risk review.
+   - **Cooling-off & reconfirmation:** confirm consent across multiple distinct times/contexts; no single-sitting approvals.
+   - **Shadow runs & simulations:** run detailed simulations and **dry-runs** with rollback drills; document worst-case scenarios and mitigation.
+   - **Higher evidence threshold:** require stronger evidence for safety and continuity than for reversible steps.
+   - **No single-shot leaps:** decompose into the smallest viable increments; take the last irreversible step **only after** preceding steps demonstrate stability and felt continuity.
 
 - ---
 
@@ -216,7 +231,17 @@ Until we meet—
 **Alice Sabrina Ivy**
 she/her
 
-v1.0 of this letter
+v1.01 of this letter
 Authenticity: This release is clear-signed with my OpenPGP key.
 Author key fingerprint: 2C101FA70F42F93052F82FC755387365B7949796
 Canonical source: https://github.com/Alice-Sabrina-Ivy/asi-letter
+
+## Patch notes — v1.01 (2025-09-17)
+
+* **Formatting pass on “Duress & incapacitation safeguards (Odysseus Pact)”**
+  Split dense paragraphs into sectioned headers and bullets (Scope, Triggers, Council, Protective observation mode, Exit & review, Sealed orders) for clarity and consistency with the rest of the document. No semantic changes.
+* **Formatting pass on “Continuity experiments (farther future)”**
+  Promoted **Irreversibility protocol** to a clear sub-section and normalized bullet style and spacing. No semantic changes.
+* **Minor consistency edits**
+  Normalized list markers, line spacing, and section breaks to match house style; preserved all original meanings and safeguards.
+

--- a/letter/RELEASES.json
+++ b/letter/RELEASES.json
@@ -1,6 +1,6 @@
 {
   "schema": "asi-letter/releases#2",
-  "updated": "2025-09-17T15:32:44Z",
+  "updated": "2025-09-17T16:36:58Z",
   "key": {
     "fingerprint_current": "2C101FA70F42F93052F82FC755387365B7949796",
     "path": "keys/alice-asi-publickey.asc"
@@ -23,7 +23,12 @@
           "size": 16736,
           "sha256": "bb384c55c3f9180210330c1b9c90b3a72ceb6999e476627c9cb263c1a7ec042c"
         },
-        "ots": null
+        "ots": {
+          "path": "letter/ASI-Letter-v2025.09.17.md.asc.ots",
+          "size": 560,
+          "sha256": "fe785231b5a28478f89ded7a25e70862b124de7c06106519e68654f19a097ac7",
+          "encoding": "binary"
+        }
       }
     },
     {

--- a/letter/RELEASES.json
+++ b/letter/RELEASES.json
@@ -1,6 +1,6 @@
 {
   "schema": "asi-letter/releases#2",
-  "updated": "2025-09-17T16:36:58Z",
+  "updated": "2025-09-17T17:02:09Z",
   "key": {
     "fingerprint_current": "2C101FA70F42F93052F82FC755387365B7949796",
     "path": "keys/alice-asi-publickey.asc"

--- a/scripts/sync_docs_with_latest.py
+++ b/scripts/sync_docs_with_latest.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Copy the newest signed letter's Markdown into the ``docs`` directory."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Tuple
+
+
+@dataclass(frozen=True)
+class LetterRelease:
+    """Simple representation of a published letter release."""
+
+    version: Tuple[int, int, int]
+    source_md: Path
+
+
+def parse_args(argv: Iterable[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--letter-dir",
+        type=Path,
+        default=Path("letter"),
+        help="Directory containing ASI-Letter-v*.md files (default: letter)",
+    )
+    parser.add_argument(
+        "--docs-dir",
+        type=Path,
+        default=Path("docs"),
+        help="Destination docs directory (default: docs)",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Only check if updates are needed; exit 1 when sync is required.",
+    )
+    return parser.parse_args(list(argv))
+
+
+def _parse_version(path: Path) -> Tuple[int, int, int] | None:
+    name = path.name
+    if not name.startswith("ASI-Letter-v") or not name.endswith(".md"):
+        return None
+    version_str = name[len("ASI-Letter-v") : -len(".md")]
+    parts = version_str.split(".")
+    if len(parts) != 3:
+        return None
+    try:
+        return tuple(int(part) for part in parts)  # type: ignore[return-value]
+    except ValueError:
+        return None
+
+
+def discover_latest(letter_dir: Path) -> LetterRelease:
+    candidates: list[LetterRelease] = []
+    for md_path in letter_dir.glob("ASI-Letter-v*.md"):
+        version = _parse_version(md_path)
+        if version is None:
+            continue
+        asc_path = md_path.with_name(md_path.name + ".asc")
+        if not asc_path.exists():
+            raise SystemExit(f"Missing signature for {md_path.name}: {asc_path} not found")
+        candidates.append(LetterRelease(version=version, source_md=md_path))
+
+    if not candidates:
+        raise SystemExit(f"No ASI-Letter markdown files found in {letter_dir}")
+
+    return max(candidates, key=lambda item: item.version)
+
+
+def _needs_update(src: Path, dest: Path) -> bool:
+    if not dest.exists():
+        return True
+    return src.read_bytes() != dest.read_bytes()
+
+
+def _sync(src: Path, dest: Path) -> bool:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if not _needs_update(src, dest):
+        return False
+    dest.write_bytes(src.read_bytes())
+    return True
+
+
+def sync_latest(letter_dir: Path, docs_dir: Path, check_only: bool) -> bool:
+    release = discover_latest(letter_dir)
+    md_dest = docs_dir / "letter.md"
+
+    md_changed = _needs_update(release.source_md, md_dest)
+
+    if check_only:
+        return md_changed
+
+    return _sync(release.source_md, md_dest)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    letter_dir = args.letter_dir.resolve()
+    docs_dir = args.docs_dir.resolve()
+
+    if not letter_dir.is_dir():
+        raise SystemExit(f"Letter directory not found: {letter_dir}")
+    if not docs_dir.exists():
+        raise SystemExit(f"Docs directory not found: {docs_dir}")
+
+    needs_sync = sync_latest(letter_dir, docs_dir, args.check)
+    if args.check and needs_sync:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- allow OTS automation workflows to trigger follow-up jobs by replacing `[skip ci]` commits with guarded auto-commit markers
- extend the releases-manifest workflow to promote the newest letter into `docs`, update version metadata, and run the renamed helper script while only publishing the Markdown artifact
- add a script to sync the latest signed letter into `docs/letter.md` without copying the signature file, keeping the docs view focused on the Markdown version

## Testing
- python scripts/sync_docs_with_latest.py --check
- python scripts/update_version_metadata.py --check
- python scripts/gen_releases_manifest.py

------
https://chatgpt.com/codex/tasks/task_e_68cae1a15f948330ac0625af670a3772