### PR TITLE
ci: wait for pages before auto commits

### DIFF
--- a/.github/scripts/wait_for_pages_idle.sh
+++ b/.github/scripts/wait_for_pages_idle.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Wait until no GitHub Pages deployment workflow is running for the target branch.
+# This avoids the built-in GitHub Pages workflow cancelling in-progress runs when
+# a new commit is pushed in quick succession.
+
+set -euo pipefail
+
+if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+  echo "GITHUB_TOKEN must be provided" >&2
+  exit 1
+fi
+
+OWNER_REPO="${GITHUB_REPOSITORY:-}"
+if [[ -z "$OWNER_REPO" ]]; then
+  echo "GITHUB_REPOSITORY is not set" >&2
+  exit 1
+fi
+
+OWNER="${OWNER_REPO%%/*}"
+REPO="${OWNER_REPO##*/}"
+BRANCH="${WAIT_FOR_PAGES_BRANCH:-${GITHUB_REF_NAME:-main}}"
+SLEEP_SECONDS="${WAIT_FOR_PAGES_SLEEP:-10}"
+TIMEOUT_SECONDS="${WAIT_FOR_PAGES_TIMEOUT:-600}"
+START_TIME="$(date +%s)"
+
+api_request() {
+  local url="$1"
+  curl -fsSL \
+    -H "Authorization: Bearer $GITHUB_TOKEN" \
+    -H "Accept: application/vnd.github+json" \
+    "$url"
+}
+
+while true; do
+  NOW="$(date +%s)"
+  if (( TIMEOUT_SECONDS > 0 )) && (( NOW - START_TIME >= TIMEOUT_SECONDS )); then
+    echo "Timed out waiting for GitHub Pages workflow to finish" >&2
+    exit 1
+  fi
+
+  RESPONSE="$(api_request "https://api.github.com/repos/${OWNER}/${REPO}/actions/runs?per_page=100&branch=${BRANCH}")"
+  COUNT="$(echo "$RESPONSE" | jq '[.workflow_runs[] | select(.name == "pages build and deployment" and (.status == "in_progress" or .status == "queued"))] | length')"
+
+  if [[ "$COUNT" == "0" ]]; then
+    echo "GitHub Pages is idle for ${BRANCH}."
+    break
+  fi
+
+  echo "Waiting for ${COUNT} GitHub Pages run(s) targeting ${BRANCH} to complete before committing..."
+  sleep "$SLEEP_SECONDS"
+done
+

--- a/.github/workflows/ots-append.yml
+++ b/.github/workflows/ots-append.yml
@@ -79,6 +79,11 @@ jobs:
             printf '%s\n' '<!-- OTS-END -->'
           } >> "$HTML"
 
+      - name: Wait for GitHub Pages to be idle
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: .github/scripts/wait_for_pages_idle.sh
+
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "chore(ots): ensure footer + status [ots-append-auto]"

--- a/.github/workflows/ots-stamp-letter-asc.yml
+++ b/.github/workflows/ots-stamp-letter-asc.yml
@@ -50,6 +50,12 @@ jobs:
           git fetch origin "$branch"
           git pull --rebase --autostash origin "$branch"
 
+      - name: Wait for GitHub Pages to be idle
+        if: steps.stamp.outputs.touched == '1'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: .github/scripts/wait_for_pages_idle.sh
+
       - uses: stefanzweifel/git-auto-commit-action@v5
         if: steps.stamp.outputs.touched == '1'
         with:

--- a/.github/workflows/ots-upgrade.yml
+++ b/.github/workflows/ots-upgrade.yml
@@ -90,6 +90,11 @@ jobs:
             }' "$HTML" > "$HTML.tmp"
           mv "$HTML.tmp" "$HTML"
 
+      - name: Wait for GitHub Pages to be idle
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: .github/scripts/wait_for_pages_idle.sh
+
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "chore(ots): upgrade proof + refresh status [ots-upgrade-auto]"

--- a/.github/workflows/ots-verify-upgrade.yml
+++ b/.github/workflows/ots-verify-upgrade.yml
@@ -49,6 +49,11 @@ jobs:
           ots verify "${{ steps.latest-ots.outputs.latest }}" || true
           echo "::endgroup::"
 
+      - name: Wait for GitHub Pages to be idle
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: .github/scripts/wait_for_pages_idle.sh
+
       - name: Commit upgraded proof if changed
         uses: stefanzweifel/git-auto-commit-action@v5
         with:

--- a/.github/workflows/releases-manifest.yml
+++ b/.github/workflows/releases-manifest.yml
@@ -29,6 +29,10 @@ jobs:
         run: python3 scripts/sync_docs_with_latest.py
       - name: Update version metadata in docs
         run: python3 scripts/update_version_metadata.py
+      - name: Wait for GitHub Pages to be idle
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: .github/scripts/wait_for_pages_idle.sh
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "chore(manifest): refresh release assets [manifest-auto]"


### PR DESCRIPTION
## Summary
- add a reusable helper that polls the GitHub API until the built-in Pages deployment workflow is idle
- call the helper from every workflow that auto-commits release or OTS updates so new pushes wait for active deployments to finish

## Testing
- bash -n .github/scripts/wait_for_pages_idle.sh

------
https://chatgpt.com/codex/tasks/task_e_68caecfafe74833092f87e3ea4487bbd