### PR TITLE
Fix ots-upgrade workflow push failures on concurrent commits

### DIFF
--- a/.github/workflows/ots-upgrade.yml
+++ b/.github/workflows/ots-upgrade.yml
@@ -90,6 +90,14 @@ jobs:
             }' "$HTML" > "$HTML.tmp"
           mv "$HTML.tmp" "$HTML"
 
+      - name: Rebase onto latest ${{ github.ref_name }} before committing
+        shell: bash
+        run: |
+          set -euo pipefail
+          branch="${GITHUB_REF##*/}"
+          git fetch origin "$branch"
+          git pull --rebase --autostash origin "$branch"
+
       - name: Wait for GitHub Pages to be idle
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- fetch and rebase onto the latest branch head in the ots-upgrade workflow before attempting the auto-commit
- ensures scheduled runs stay up-to-date even when other automations push to main around the same time

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68caf219ee108330810fcf4f580af8c5