### PR TITLE
Fix workflow permissions for wait_for_pages script

### DIFF
--- a/.github/workflows/ots-append.yml
+++ b/.github/workflows/ots-append.yml
@@ -17,6 +17,7 @@ concurrency:
 
 permissions:
   contents: write
+  actions: read
 
 jobs:
   append-proof:

--- a/.github/workflows/ots-stamp-letter-asc.yml
+++ b/.github/workflows/ots-stamp-letter-asc.yml
@@ -11,6 +11,7 @@ concurrency:
 
 permissions:
   contents: write
+  actions: read
 
 jobs:
   stamp-letter-asc:

--- a/.github/workflows/ots-upgrade.yml
+++ b/.github/workflows/ots-upgrade.yml
@@ -10,6 +10,7 @@ concurrency:
 
 permissions:
   contents: write
+  actions: read
 
 jobs:
   upgrade-and-update:

--- a/.github/workflows/ots-verify-upgrade.yml
+++ b/.github/workflows/ots-verify-upgrade.yml
@@ -8,6 +8,7 @@ concurrency:
 
 permissions:
   contents: write
+  actions: read
 
 jobs:
   verify-upgrade:

--- a/.github/workflows/releases-manifest.yml
+++ b/.github/workflows/releases-manifest.yml
@@ -13,6 +13,7 @@ concurrency:
 
 permissions:
   contents: write
+  actions: read
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- add the actions: read scope to every workflow that calls wait_for_pages_idle.sh so the script can query workflow runs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68caf77a17f08330b8df78d8d8161a13