### PR TITLE
Fix manifest workflow pushes on main branch

### DIFF
--- a/.github/workflows/releases-manifest.yml
+++ b/.github/workflows/releases-manifest.yml
@@ -45,6 +45,7 @@ jobs:
         run: .github/scripts/wait_for_pages_idle.sh
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
+          branch: ${{ github.ref_name }}
           commit_message: "chore(manifest): refresh release assets [manifest-auto]"
           file_pattern: |
             letter/RELEASES.json


### PR DESCRIPTION
## Summary
- ensure the manifest auto-commit step checks out and pushes to the current ref name

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cb0037977c8330aa1efdc52d49b58d