### PR TITLE
fix: trigger ots workflows after release sync

### DIFF
--- a/.github/workflows/ots-append.yml
+++ b/.github/workflows/ots-append.yml
@@ -7,6 +7,7 @@ on:
   workflow_run:
     workflows:
       - ots-upgrade
+      - releases-manifest
     types:
       - completed
   workflow_dispatch: {}

--- a/.github/workflows/ots-upgrade.yml
+++ b/.github/workflows/ots-upgrade.yml
@@ -3,6 +3,11 @@ on:
   schedule:
     - cron: "23 * * * *"
   workflow_dispatch: {}
+  workflow_run:
+    workflows:
+      - releases-manifest
+    types:
+      - completed
 
 concurrency:
   group: letter-artifacts-${{ github.ref }}
@@ -14,6 +19,7 @@ permissions:
 
 jobs:
   upgrade-and-update:
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/releases-manifest.yml
+++ b/.github/workflows/releases-manifest.yml
@@ -29,7 +29,9 @@ jobs:
       - name: Generate manifest (python)
         run: python3 scripts/gen_releases_manifest.py
       - name: Sync docs with latest letter
-        run: python3 scripts/sync_docs_with_latest.py
+        run: |
+          python3 scripts/sync_docs_with_latest.py
+          python3 scripts/sync_docs_with_latest.py --check
       - name: Update version metadata in docs
         run: python3 scripts/update_version_metadata.py
       - name: Rebase onto latest ${{ github.ref_name }} before committing


### PR DESCRIPTION
## Summary
- run `ots-upgrade` automatically once the release manifest workflow finishes successfully
- allow `ots-append` to react to either an upgrade run or a completed release manifest so the footer refresh happens reliably
- harden the release manifest workflow so syncing docs fails fast if the Markdown copy does not actually update

## Testing
- python3 scripts/sync_docs_with_latest.py
- python3 scripts/sync_docs_with_latest.py --check


------
https://chatgpt.com/codex/tasks/task_e_68cb099d06988330b2513231246c7c08