### PR TITLE
Add release orchestration helper

### DIFF
--- a/.github/workflows/releases-manifest.yml
+++ b/.github/workflows/releases-manifest.yml
@@ -34,7 +34,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          branch="${GITHUB_REF##*/}"
+          branch="${GITHUB_REF_NAME:-${GITHUB_REF#refs/heads/}}"
+          if [[ -z "${branch}" ]]; then
+            echo "Unable to determine branch name from GITHUB_REF/GITHUB_REF_NAME" >&2
+            exit 1
+          fi
           git fetch origin "$branch"
           git pull --rebase --autostash origin "$branch"
       - name: Wait for GitHub Pages to be idle

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: release
+
+release:
+	python3 scripts/release.py

--- a/letter/RELEASES.json
+++ b/letter/RELEASES.json
@@ -1,6 +1,6 @@
 {
   "schema": "asi-letter/releases#2",
-  "updated": "2025-09-17T19:14:19Z",
+  "updated": "2025-09-17T23:18:19Z",
   "key": {
     "fingerprint_current": "2C101FA70F42F93052F82FC755387365B7949796",
     "path": "keys/alice-asi-publickey.asc"
@@ -23,7 +23,12 @@
           "size": 16736,
           "sha256": "bb384c55c3f9180210330c1b9c90b3a72ceb6999e476627c9cb263c1a7ec042c"
         },
-        "ots": null
+        "ots": {
+          "path": "letter/ASI-Letter-v2025.09.17.md.asc.ots",
+          "size": 700,
+          "sha256": "546c8882a4a34b5db854ebab055efa218b9f6a7effb39be4e31c9986f8949c56",
+          "encoding": "binary"
+        }
       }
     },
     {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,41 @@
+# Scripts
+
+This directory collects automation helpers that keep the published assets in
+sync with the latest signed ASI Letter. The most common workflow is driven by
+`release.py`, which orchestrates the individual steps so contributors do not
+need to remember the correct order.
+
+## `release.py`
+
+```
+python3 scripts/release.py [--check|--dry-run] [--skip-sync] [--skip-manifest] [--skip-metadata]
+```
+
+* Runs the scripts in the following order, aborting on the first failure:
+  1. `sync_docs_with_latest.py`
+  2. `gen_releases_manifest.py`
+  3. `update_version_metadata.py`
+* Pass `--check` or `--dry-run` to forward the read-only mode supported by the
+  underlying tools. This is useful in CI or when verifying that the working tree
+  is already up to date.
+* Advanced users can re-run a specific stage by combining the `--skip-…`
+  switches shown above.
+
+When regenerating assets for a new release you can simply run:
+
+```
+python3 scripts/release.py
+```
+
+If you prefer `make`, use the `release` target described below.
+
+## Make integration
+
+A convenience `release` target is provided so contributors can run the whole
+pipeline via `make`:
+
+```
+make release
+```
+
+This is equivalent to invoking `python3 scripts/release.py` directly.

--- a/scripts/gen_releases_manifest.py
+++ b/scripts/gen_releases_manifest.py
@@ -247,7 +247,9 @@ def _equivalent_without_updated(
 
 
 def main(argv: Iterable[str] | None = None) -> int:
-    args = parse_args(argv or sys.argv[1:])
+    if argv is None:
+        argv = sys.argv[1:]
+    args = parse_args(argv)
     base = repo_root(Path.cwd())
     try:
         manifest = build_manifest(base)

--- a/scripts/gen_releases_manifest.py
+++ b/scripts/gen_releases_manifest.py
@@ -3,14 +3,16 @@
 
 from __future__ import annotations
 
+import argparse
 import datetime as dt
 import hashlib
+import json
 import os
 import re
 import subprocess
 import sys
 from pathlib import Path, PurePosixPath
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 
 RE_VERSION = re.compile(r"ASI-Letter-v(?P<ver>\d{4}\.\d{2}\.\d{2})\.md\Z")
@@ -18,6 +20,22 @@ RE_VERSION = re.compile(r"ASI-Letter-v(?P<ver>\d{4}\.\d{2}\.\d{2})\.md\Z")
 
 class ManifestError(RuntimeError):
     """Raised when manifest generation fails."""
+
+
+def parse_args(argv: Iterable[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Only verify whether RELEASES.json is current; exit 1 if regeneration is needed.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("letter/RELEASES.json"),
+        help="Destination manifest path (default: letter/RELEASES.json).",
+    )
+    return parser.parse_args(list(argv))
 
 
 def _run_git_rev_parse(start: Path) -> Optional[Path]:
@@ -195,14 +213,41 @@ def build_manifest(base: Path) -> Dict[str, Any]:
     }
 
 
-def write_manifest(manifest: Dict[str, Any], output_path: Path) -> None:
-    import json
+def serialize_manifest(manifest: Dict[str, Any]) -> str:
+    return json.dumps(manifest, indent=2)
 
-    json_text = json.dumps(manifest, indent=2)
+
+def write_manifest(manifest: Dict[str, Any], output_path: Path) -> None:
+    json_text = serialize_manifest(manifest)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json_text, encoding="utf-8")
 
 
+def load_existing_manifest(path: Path) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None, None
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ManifestError(f"Existing manifest is invalid JSON: {path}\n{exc}") from exc
+    return data, text
+
+
+def _equivalent_without_updated(
+    proposed: Dict[str, Any],
+    existing: Dict[str, Any],
+) -> bool:
+    proposed_copy = dict(proposed)
+    existing_copy = dict(existing)
+    proposed_copy.pop("updated", None)
+    existing_copy.pop("updated", None)
+    return proposed_copy == existing_copy
+
+
 def main(argv: Iterable[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
     base = repo_root(Path.cwd())
     try:
         manifest = build_manifest(base)
@@ -210,9 +255,38 @@ def main(argv: Iterable[str] | None = None) -> int:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
 
-    output_path = base / "letter" / "RELEASES.json"
+    output_path = args.output
+    if not output_path.is_absolute():
+        output_path = base / output_path
+
+    try:
+        existing_manifest, existing_text = load_existing_manifest(output_path)
+    except ManifestError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    if existing_manifest is not None and _equivalent_without_updated(manifest, existing_manifest):
+        manifest["updated"] = existing_manifest.get("updated", manifest["updated"])
+
+    new_text = serialize_manifest(manifest)
+    rel_path = relativize(output_path, base)
+
+    if args.check:
+        if existing_text is None:
+            print(f"{rel_path} is missing and must be generated", file=sys.stderr)
+            return 1
+        if existing_text != new_text:
+            print(f"{rel_path} is out of date", file=sys.stderr)
+            return 1
+        print(f"{rel_path} is up to date")
+        return 0
+
+    if existing_text == new_text:
+        print(f"{rel_path} is already current")
+        return 0
+
     write_manifest(manifest, output_path)
-    print(f"Wrote {relativize(output_path, base)}")
+    print(f"Wrote {rel_path}")
     return 0
 
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -90,7 +90,9 @@ def run_stage(stage: Stage, base_dir: Path, check_mode: bool) -> None:
 
 
 def main(argv: Iterable[str] | None = None) -> int:
-    args = parse_args(argv or sys.argv[1:])
+    if argv is None:
+        argv = sys.argv[1:]
+    args = parse_args(argv)
     check_mode = bool(args.check or args.dry_run)
 
     repo_root = Path(__file__).resolve().parents[1]

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Run release automation helpers in sequence.
+
+This orchestrator coordinates the existing scripts that keep the project
+artifacts in sync with the most recent signed letter. It runs each stage in
+order, stopping on the first failure and providing a convenient ``--check`` mode
+that ensures no files would be modified.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List
+
+
+@dataclass(frozen=True)
+class Stage:
+    """Definition of a single release stage."""
+
+    name: str
+    script: str
+    skip_flag: str
+    help_text: str
+
+    @property
+    def cli_option(self) -> str:
+        return f"--{self.skip_flag.replace('_', '-')}"
+
+
+STAGES: List[Stage] = [
+    Stage(
+        name="Sync docs with latest release",
+        script="sync_docs_with_latest.py",
+        skip_flag="skip_sync",
+        help_text="the documentation sync step",
+    ),
+    Stage(
+        name="Generate releases manifest",
+        script="gen_releases_manifest.py",
+        skip_flag="skip_manifest",
+        help_text="manifest generation",
+    ),
+    Stage(
+        name="Update version metadata",
+        script="update_version_metadata.py",
+        skip_flag="skip_metadata",
+        help_text="metadata updates",
+    ),
+]
+
+
+def parse_args(argv: Iterable[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Verify whether all stages are clean without applying changes.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Alias for --check for contributors that prefer the term.",
+    )
+    for stage in STAGES:
+        parser.add_argument(
+            stage.cli_option,
+            action="store_true",
+            dest=stage.skip_flag,
+            help=f"Skip {stage.help_text}.",
+        )
+    return parser.parse_args(list(argv))
+
+
+def run_stage(stage: Stage, base_dir: Path, check_mode: bool) -> None:
+    script_path = base_dir / "scripts" / stage.script
+    if not script_path.exists():
+        raise SystemExit(f"Script not found: {script_path}")
+
+    cmd = [sys.executable, str(script_path)]
+    if check_mode:
+        cmd.append("--check")
+
+    mode_label = " (check mode)" if check_mode else ""
+    print(f"  → Running {stage.name}{mode_label}...")
+    subprocess.run(cmd, check=True, cwd=base_dir)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    check_mode = bool(args.check or args.dry_run)
+
+    repo_root = Path(__file__).resolve().parents[1]
+
+    selected: List[Stage] = []
+    for stage in STAGES:
+        if getattr(args, stage.skip_flag):
+            print(f"Skipping {stage.name} ({stage.cli_option})")
+        else:
+            selected.append(stage)
+
+    if not selected:
+        print("All stages skipped; nothing to do.")
+        return 0
+
+    total = len(selected)
+    for index, stage in enumerate(selected, start=1):
+        print(f"[{index}/{total}] {stage.name}")
+        run_stage(stage, repo_root, check_mode)
+
+    print("All release stages completed successfully.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sync_docs_with_latest.py
+++ b/scripts/sync_docs_with_latest.py
@@ -98,7 +98,9 @@ def sync_latest(letter_dir: Path, docs_dir: Path, check_only: bool) -> bool:
 
 
 def main(argv: Iterable[str] | None = None) -> int:
-    args = parse_args(argv or sys.argv[1:])
+    if argv is None:
+        argv = sys.argv[1:]
+    args = parse_args(argv)
     letter_dir = args.letter_dir.resolve()
     docs_dir = args.docs_dir.resolve()
 


### PR DESCRIPTION
## Summary
- add a release orchestrator that runs the sync, manifest, and metadata helpers with optional check/dry-run and skip flags
- extend the manifest generator with a --check mode, idempotent writes, and refresh the manifest to include the newest OTS artifact
- document the workflow in scripts/README.md and add a make release target for convenience

## Testing
- python3 scripts/release.py
- python3 scripts/release.py --check
- python3 scripts/release.py --skip-manifest --check
- make release

------
https://chatgpt.com/codex/tasks/task_e_68cb40b579708330b28e0a923aa4608e