### PR TITLE
Stop scheduled ots-upgrade runs after timestamp finalizes

### DIFF
--- a/.github/workflows/ots-upgrade.yml
+++ b/.github/workflows/ots-upgrade.yml
@@ -22,31 +22,67 @@ permissions:
   actions: read
 
 jobs:
+  precheck:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.decision.outputs.should_run }}
+    steps:
+      - name: Determine whether scheduled run should proceed
+        id: decision
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const eventName = context.eventName;
+            if (eventName !== 'schedule') {
+              core.info(`Event "${eventName}" is not schedule; proceeding.`);
+              core.setOutput('should_run', 'true');
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+            const refFromContext = context.ref ? context.ref.replace(/^refs\/heads\//, '') : null;
+            const fallbackRef = context.payload?.repository?.default_branch || 'main';
+            const ref = refFromContext || fallbackRef;
+
+            try {
+              const response = await github.repos.getContent({
+                owner,
+                repo,
+                path: 'docs/index.html',
+                ref,
+              });
+
+              const data = response.data;
+              if (!data || data.type !== 'file') {
+                core.info('docs/index.html not found as a file; proceeding.');
+                core.setOutput('should_run', 'true');
+                return;
+              }
+
+              const buffer = Buffer.from(data.content, data.encoding || 'base64');
+              const content = buffer.toString('utf8');
+              if (/Bitcoin block <strong>[0-9]+/.test(content)) {
+                core.info('Detected finalized Bitcoin block in docs/index.html; skipping scheduled run.');
+                core.setOutput('should_run', 'false');
+                return;
+              }
+            } catch (error) {
+              core.warning(`Unable to inspect docs/index.html for schedule precheck: ${error.message || error}`);
+              core.setOutput('should_run', 'true');
+              return;
+            }
+
+            core.info('No finalized Bitcoin block detected; proceeding.');
+            core.setOutput('should_run', 'true');
+
   upgrade-and-update:
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    needs: precheck
+    if: ${{ (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success') && needs.precheck.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Detect prior Bitcoin attestation for scheduled runs
-        id: maybe_skip
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-        run: |
-          set -euo pipefail
-
-          SHOULD_SKIP="false"
-          if [[ "$EVENT_NAME" == "schedule" ]]; then
-            if [[ -f docs/index.html ]] && grep -Eq 'Bitcoin block <strong>[0-9]+' docs/index.html; then
-              echo "Scheduled run detected an existing Bitcoin block attestation in docs/index.html; skipping upgrade."
-              SHOULD_SKIP="true"
-            fi
-          fi
-
-          printf 'should_skip=%s\n' "$SHOULD_SKIP" >> "$GITHUB_OUTPUT"
-
       - name: Install OpenTimestamps client + alt verifier
-        if: steps.maybe_skip.outputs.should_skip != 'true'
         run: |
           python -m pip install --upgrade opentimestamps-client
           wget -q https://go.dev/dl/go1.22.5.linux-amd64.tar.gz
@@ -59,7 +95,6 @@ jobs:
 
       - name: Prepare proof + determine footer status
         id: status
-        if: steps.maybe_skip.outputs.should_skip != 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -119,7 +154,6 @@ jobs:
           printf 'status_line=%s\n' "$STATUS_SANITIZED" >> "$GITHUB_OUTPUT"
 
       - name: Ensure footer (scriptless, centered)
-        if: steps.maybe_skip.outputs.should_skip != 'true'
         shell: bash
         env:
           STATUS_LINE: ${{ steps.status.outputs.status_line }}
@@ -144,7 +178,6 @@ jobs:
           } >> "$HTML"
 
       - name: Rebase onto latest ${{ github.ref_name }} before committing
-        if: steps.maybe_skip.outputs.should_skip != 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -153,13 +186,11 @@ jobs:
           git pull --rebase --autostash origin "$branch"
 
       - name: Wait for GitHub Pages to be idle
-        if: steps.maybe_skip.outputs.should_skip != 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: .github/scripts/wait_for_pages_idle.sh
 
       - uses: stefanzweifel/git-auto-commit-action@v5
-        if: steps.maybe_skip.outputs.should_skip != 'true'
         with:
           commit_message: "chore(ots): upgrade proof + refresh status [ots-upgrade-auto]"
           file_pattern: docs/index.html


### PR DESCRIPTION
## Summary
- add a lightweight precheck job that inspects docs/index.html before running the upgrade
- skip the heavy ots-upgrade job for scheduled triggers once a Bitcoin block height is present

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d1d12d382c8330ab99260a616bb9cb