### PR TITLE
Stop scheduled ots-upgrade runs after timestamp finalizes

### DIFF
--- a/.github/workflows/ots-upgrade.yml
+++ b/.github/workflows/ots-upgrade.yml
@@ -9,6 +9,8 @@ on:
     types:
       - completed
   push:
+    branches:
+      - main
     paths:
       - "docs/letter.md"
       - "docs/index.html"
@@ -29,76 +31,93 @@ jobs:
     steps:
       - name: Determine whether scheduled run should proceed
         id: decision
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const eventName = context.eventName;
-            if (eventName !== 'schedule') {
-              core.info(`Event "${eventName}" is not schedule; proceeding.`);
-              core.setOutput('should_run', 'true');
-              return;
-            }
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          REF: ${{ github.ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch || 'main' }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
 
-            const { owner, repo } = context.repo;
-            const refFromContext = context.ref ? context.ref.replace(/^refs\/heads\//, '') : null;
-            const fallbackRef = context.payload?.repository?.default_branch || 'main';
-            const ref = refFromContext || fallbackRef;
+          python - <<'PY'
+          import html
+          import os
+          import re
+          import sys
+          import urllib.request
 
-            try {
-              const { data } = await github.request('GET /repos/{owner}/{repo}/contents/{path}', {
-                owner,
-                repo,
-                path: 'docs/index.html',
-                ref,
-              });
+          event_name = os.environ.get('EVENT_NAME', '')
+          gh_output = os.environ.get('GITHUB_OUTPUT')
+          if not gh_output:
+              raise SystemExit('GITHUB_OUTPUT is not set')
 
-              if (Array.isArray(data)) {
-                core.info('docs/index.html resolved as a directory listing; proceeding.');
-                core.setOutput('should_run', 'true');
-                return;
-              }
+          with open(gh_output, 'a', encoding='utf-8') as out:
+              if event_name != 'schedule':
+                  print(f"Event '{event_name}' is not schedule; proceeding.")
+                  print('should_run=true', file=out)
+                  raise SystemExit(0)
 
-              if (typeof data === 'string') {
-                if (/Bitcoin block\s*<strong>\d+/.test(data)) {
-                  core.notice('Detected finalized Bitcoin block in docs/index.html; skipping scheduled run.');
-                  core.setOutput('should_run', 'false');
-                  return;
-                }
+              ref_name = os.environ.get('REF_NAME') or ''
+              if not ref_name:
+                  ref = os.environ.get('REF', '')
+                  if ref.startswith('refs/heads/'):
+                      ref_name = ref.split('/', 2)[2]
+              if not ref_name:
+                  ref_name = os.environ.get('DEFAULT_BRANCH', 'main') or 'main'
 
-                core.info('docs/index.html returned as string without metadata; proceeding.');
-                core.setOutput('should_run', 'true');
-                return;
-              }
+              repository = os.environ.get('REPOSITORY')
+              if not repository:
+                  print('Missing repository context; proceeding.', file=sys.stderr)
+                  print('should_run=true', file=out)
+                  raise SystemExit(0)
 
-              if (!data || typeof data !== 'object' || data.type !== 'file' || typeof data.content !== 'string') {
-                core.info('docs/index.html not returned as decodable file content; proceeding.');
-                core.setOutput('should_run', 'true');
-                return;
-              }
+              url = f"https://raw.githubusercontent.com/{repository}/{ref_name}/docs/index.html"
+              print(f"Fetching {url}")
 
-              const encoding = typeof data.encoding === 'string' && data.encoding.length > 0 ? data.encoding : 'base64';
-              let content = '';
-              try {
-                content = Buffer.from(data.content, encoding).toString('utf8');
-              } catch (decodeError) {
-                core.warning(`Unable to decode docs/index.html (${encoding}): ${decodeError.message || decodeError}`);
-                core.setOutput('should_run', 'true');
-                return;
-              }
+              request = urllib.request.Request(
+                  url,
+                  headers={
+                      'User-Agent': 'asi-letter-ots-precheck',
+                      'Cache-Control': 'no-cache',
+                      'Pragma': 'no-cache',
+                  },
+              )
 
-              if (/Bitcoin block\s*<strong>\d+/.test(content)) {
-                core.notice('Detected finalized Bitcoin block in docs/index.html; skipping scheduled run.');
-                core.setOutput('should_run', 'false');
-                return;
-              }
-            } catch (error) {
-              core.warning(`Unable to inspect docs/index.html for schedule precheck: ${error.message || error}`);
-              core.setOutput('should_run', 'true');
-              return;
-            }
+              try:
+                  with urllib.request.urlopen(request, timeout=30) as resp:
+                      page = resp.read().decode('utf-8', 'replace')
+              except Exception as exc:
+                  print(f"Unable to download docs/index.html; proceeding: {exc}", file=sys.stderr)
+                  print('should_run=true', file=out)
+                  raise SystemExit(0)
 
-            core.info('No finalized Bitcoin block detected; proceeding.');
-            core.setOutput('should_run', 'true');
+              normalized = html.unescape(page)
+              normalized = normalized.replace('\r', ' ')
+
+              patterns = [
+                  re.compile(r'Bitcoin\s+block[^<]*<strong>\s*#?([\d,]+)', re.IGNORECASE),
+                  re.compile(r'blockheight[^<]*<strong>\s*#?([\d,]+)', re.IGNORECASE),
+                  re.compile(r'BitcoinBlockHeaderAttestation\((\d+)\)', re.IGNORECASE),
+              ]
+
+              block_value = None
+              for pattern in patterns:
+                  match = pattern.search(normalized)
+                  if match:
+                      block_value = match.group(1)
+                      break
+
+              if block_value:
+                  block_digits = re.sub(r'\D', '', block_value)
+                  if block_digits:
+                      print(f"Detected finalized Bitcoin block in docs/index.html (height {block_digits}); skipping scheduled run.")
+                      print('should_run=false', file=out)
+                      raise SystemExit(0)
+
+              print('No finalized Bitcoin block detected; proceeding.')
+              print('should_run=true', file=out)
+          PY
 
   upgrade-and-update:
     needs: precheck
@@ -204,11 +223,22 @@ jobs:
 
       - name: Rebase onto latest ${{ github.ref_name }} before committing
         shell: bash
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch || 'main' }}
         run: |
           set -euo pipefail
+
           branch="${GITHUB_REF##*/}"
-          git fetch origin "$branch"
-          git pull --rebase --autostash origin "$branch"
+          if [[ -z "$branch" || "$branch" == "$GITHUB_REF" ]]; then
+            branch="${DEFAULT_BRANCH:-main}"
+          fi
+
+          if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+            git fetch origin "$branch"
+            git pull --rebase --autostash origin "$branch"
+          else
+            echo "Branch '$branch' not published on origin; skipping rebase."
+          fi
 
       - name: Wait for GitHub Pages to be idle
         env:

--- a/.github/workflows/ots-upgrade.yml
+++ b/.github/workflows/ots-upgrade.yml
@@ -37,20 +37,47 @@ jobs:
           REF: ${{ github.ref }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch || 'main' }}
           REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
           python - <<'PY'
+          import base64
           import html
+          import json
           import os
           import re
           import sys
+          import urllib.parse
           import urllib.request
 
           event_name = os.environ.get('EVENT_NAME', '')
           gh_output = os.environ.get('GITHUB_OUTPUT')
           if not gh_output:
               raise SystemExit('GITHUB_OUTPUT is not set')
+
+          token = os.environ.get('GITHUB_TOKEN', '')
+
+          def detect_block(document):
+              if not document:
+                  return None
+
+              normalized = html.unescape(document)
+              normalized = normalized.replace('\r', ' ')
+
+              patterns = [
+                  re.compile(r'Bitcoin\s+block[^<]*<strong>\s*#?([\d,]+)', re.IGNORECASE),
+                  re.compile(r'blockheight[^<]*<strong>\s*#?([\d,]+)', re.IGNORECASE),
+                  re.compile(r'BitcoinBlockHeaderAttestation\((\d+)\)', re.IGNORECASE),
+              ]
+
+              for pattern in patterns:
+                  match = pattern.search(normalized)
+                  if match:
+                      digits = re.sub(r'\D', '', match.group(1))
+                      if digits:
+                          return digits
+              return None
 
           with open(gh_output, 'a', encoding='utf-8') as out:
               if event_name != 'schedule':
@@ -75,43 +102,69 @@ jobs:
               url = f"https://raw.githubusercontent.com/{repository}/{ref_name}/docs/index.html"
               print(f"Fetching {url}")
 
-              request = urllib.request.Request(
-                  url,
-                  headers={
-                      'User-Agent': 'asi-letter-ots-precheck',
-                      'Cache-Control': 'no-cache',
-                      'Pragma': 'no-cache',
-                  },
-              )
+              headers = {
+                  'User-Agent': 'asi-letter-ots-precheck',
+                  'Cache-Control': 'no-cache',
+                  'Pragma': 'no-cache',
+              }
+              if token:
+                  headers['Authorization'] = f'Bearer {token}'
 
+              raw_request = urllib.request.Request(url, headers=headers)
+
+              document = None
               try:
-                  with urllib.request.urlopen(request, timeout=30) as resp:
-                      page = resp.read().decode('utf-8', 'replace')
+                  with urllib.request.urlopen(raw_request, timeout=30) as resp:
+                      encoding = resp.headers.get_content_charset() or 'utf-8'
+                      document = resp.read().decode(encoding, 'replace')
               except Exception as exc:
-                  print(f"Unable to download docs/index.html; proceeding: {exc}", file=sys.stderr)
-                  print('should_run=true', file=out)
-                  raise SystemExit(0)
+                  print(f"Raw download failed: {exc}", file=sys.stderr)
 
-              normalized = html.unescape(page)
-              normalized = normalized.replace('\r', ' ')
+              if document is None and token:
+                  api_url = "https://api.github.com/repos/{repo}/contents/docs/index.html?ref={ref}".format(
+                      repo=repository,
+                      ref=urllib.parse.quote(ref_name, safe=''),
+                  )
+                  api_request = urllib.request.Request(
+                      api_url,
+                      headers={
+                          'User-Agent': 'asi-letter-ots-precheck',
+                          'Authorization': f'Bearer {token}',
+                          'Accept': 'application/vnd.github+json',
+                      },
+                  )
+                  try:
+                      with urllib.request.urlopen(api_request, timeout=30) as resp:
+                          payload = resp.read().decode('utf-8', 'replace')
+                          data = json.loads(payload)
+                      if isinstance(data, dict) and data.get('type') == 'file':
+                          content = data.get('content')
+                          encoding = (data.get('encoding') or 'base64').lower()
+                          if isinstance(content, str):
+                              document = None
+                              if encoding == 'base64':
+                                  try:
+                                      document = base64.b64decode(content).decode('utf-8', 'replace')
+                                  except Exception as exc:
+                                      print(
+                                          f"Unable to decode docs/index.html from API response ({encoding}): {exc}",
+                                          file=sys.stderr,
+                                      )
+                              if document is None:
+                                  document = content
+                          else:
+                              print('docs/index.html content missing or not string in API response; proceeding.', file=sys.stderr)
+                      else:
+                          print('docs/index.html not returned as file content via API; proceeding.', file=sys.stderr)
+                  except Exception as exc:
+                      print(f"Contents API fallback failed: {exc}", file=sys.stderr)
 
-              patterns = [
-                  re.compile(r'Bitcoin\s+block[^<]*<strong>\s*#?([\d,]+)', re.IGNORECASE),
-                  re.compile(r'blockheight[^<]*<strong>\s*#?([\d,]+)', re.IGNORECASE),
-                  re.compile(r'BitcoinBlockHeaderAttestation\((\d+)\)', re.IGNORECASE),
-              ]
-
-              block_value = None
-              for pattern in patterns:
-                  match = pattern.search(normalized)
-                  if match:
-                      block_value = match.group(1)
-                      break
-
-              if block_value:
-                  block_digits = re.sub(r'\D', '', block_value)
+              if document:
+                  block_digits = detect_block(document)
                   if block_digits:
-                      print(f"Detected finalized Bitcoin block in docs/index.html (height {block_digits}); skipping scheduled run.")
+                      print(
+                          f"Detected finalized Bitcoin block in docs/index.html (height {block_digits}); skipping scheduled run."
+                      )
                       print('should_run=false', file=out)
                       raise SystemExit(0)
 

--- a/.github/workflows/ots-upgrade.yml
+++ b/.github/workflows/ots-upgrade.yml
@@ -10,7 +10,7 @@ on:
       - completed
   push:
     paths:
-      - "docs/letter.md.asc"
+      - "docs/letter.md"
       - "docs/index.html"
 
 concurrency:
@@ -22,31 +22,92 @@ permissions:
   actions: read
 
 jobs:
+  precheck:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.decision.outputs.should_run }}
+    steps:
+      - name: Determine whether scheduled run should proceed
+        id: decision
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const eventName = context.eventName;
+            if (eventName !== 'schedule') {
+              core.info(`Event "${eventName}" is not schedule; proceeding.`);
+              core.setOutput('should_run', 'true');
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+            const refFromContext = context.ref ? context.ref.replace(/^refs\/heads\//, '') : null;
+            const fallbackRef = context.payload?.repository?.default_branch || 'main';
+            const ref = refFromContext || fallbackRef;
+
+            try {
+              const { data } = await github.request('GET /repos/{owner}/{repo}/contents/{path}', {
+                owner,
+                repo,
+                path: 'docs/index.html',
+                ref,
+              });
+
+              if (Array.isArray(data)) {
+                core.info('docs/index.html resolved as a directory listing; proceeding.');
+                core.setOutput('should_run', 'true');
+                return;
+              }
+
+              if (typeof data === 'string') {
+                if (/Bitcoin block\s*<strong>\d+/.test(data)) {
+                  core.notice('Detected finalized Bitcoin block in docs/index.html; skipping scheduled run.');
+                  core.setOutput('should_run', 'false');
+                  return;
+                }
+
+                core.info('docs/index.html returned as string without metadata; proceeding.');
+                core.setOutput('should_run', 'true');
+                return;
+              }
+
+              if (!data || typeof data !== 'object' || data.type !== 'file' || typeof data.content !== 'string') {
+                core.info('docs/index.html not returned as decodable file content; proceeding.');
+                core.setOutput('should_run', 'true');
+                return;
+              }
+
+              const encoding = typeof data.encoding === 'string' && data.encoding.length > 0 ? data.encoding : 'base64';
+              let content = '';
+              try {
+                content = Buffer.from(data.content, encoding).toString('utf8');
+              } catch (decodeError) {
+                core.warning(`Unable to decode docs/index.html (${encoding}): ${decodeError.message || decodeError}`);
+                core.setOutput('should_run', 'true');
+                return;
+              }
+
+              if (/Bitcoin block\s*<strong>\d+/.test(content)) {
+                core.notice('Detected finalized Bitcoin block in docs/index.html; skipping scheduled run.');
+                core.setOutput('should_run', 'false');
+                return;
+              }
+            } catch (error) {
+              core.warning(`Unable to inspect docs/index.html for schedule precheck: ${error.message || error}`);
+              core.setOutput('should_run', 'true');
+              return;
+            }
+
+            core.info('No finalized Bitcoin block detected; proceeding.');
+            core.setOutput('should_run', 'true');
+
   upgrade-and-update:
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    needs: precheck
+    if: ${{ (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success') && needs.precheck.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Detect prior Bitcoin attestation for scheduled runs
-        id: maybe_skip
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-        run: |
-          set -euo pipefail
-
-          SHOULD_SKIP="false"
-          if [[ "$EVENT_NAME" == "schedule" ]]; then
-            if [[ -f docs/index.html ]] && grep -Eq 'Bitcoin block <strong>[0-9]+' docs/index.html; then
-              echo "Scheduled run detected an existing Bitcoin block attestation in docs/index.html; skipping upgrade."
-              SHOULD_SKIP="true"
-            fi
-          fi
-
-          printf 'should_skip=%s\n' "$SHOULD_SKIP" >> "$GITHUB_OUTPUT"
-
       - name: Install OpenTimestamps client + alt verifier
-        if: steps.maybe_skip.outputs.should_skip != 'true'
         run: |
           python -m pip install --upgrade opentimestamps-client
           wget -q https://go.dev/dl/go1.22.5.linux-amd64.tar.gz
@@ -59,7 +120,6 @@ jobs:
 
       - name: Prepare proof + determine footer status
         id: status
-        if: steps.maybe_skip.outputs.should_skip != 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -119,7 +179,6 @@ jobs:
           printf 'status_line=%s\n' "$STATUS_SANITIZED" >> "$GITHUB_OUTPUT"
 
       - name: Ensure footer (scriptless, centered)
-        if: steps.maybe_skip.outputs.should_skip != 'true'
         shell: bash
         env:
           STATUS_LINE: ${{ steps.status.outputs.status_line }}
@@ -144,7 +203,6 @@ jobs:
           } >> "$HTML"
 
       - name: Rebase onto latest ${{ github.ref_name }} before committing
-        if: steps.maybe_skip.outputs.should_skip != 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -153,13 +211,11 @@ jobs:
           git pull --rebase --autostash origin "$branch"
 
       - name: Wait for GitHub Pages to be idle
-        if: steps.maybe_skip.outputs.should_skip != 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: .github/scripts/wait_for_pages_idle.sh
 
       - uses: stefanzweifel/git-auto-commit-action@v5
-        if: steps.maybe_skip.outputs.should_skip != 'true'
         with:
           commit_message: "chore(ots): upgrade proof + refresh status [ots-upgrade-auto]"
           file_pattern: docs/index.html

--- a/docs/index.html
+++ b/docs/index.html
@@ -230,6 +230,6 @@
 <!-- OTS-START -->
 <section id="timestamp-proof" style="max-width:48rem;margin:2rem auto 0 auto;padding-top:1rem;border-top:1px solid #e5e7eb;text-align:center;font-size:0.95rem;line-height:1.5;">
   <h3 style="margin:0 0 .5rem 0;font-size:1.05rem;">Timestamp proof (Bitcoin)</h3>
-  <p id="ots-line">Bitcoin block <strong>915229</strong> attests the letter existed prior to that block.</p>
+  <p id="ots-line">Bitcoin block <strong>915128</strong> attests the letter existed prior to that block.</p>
 </section>
 <!-- OTS-END -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -230,6 +230,6 @@
 <!-- OTS-START -->
 <section id="timestamp-proof" style="max-width:48rem;margin:2rem auto 0 auto;padding-top:1rem;border-top:1px solid #e5e7eb;text-align:center;font-size:0.95rem;line-height:1.5;">
   <h3 style="margin:0 0 .5rem 0;font-size:1.05rem;">Timestamp proof (Bitcoin)</h3>
-  <p id="ots-line">Bitcoin block <strong>915128</strong> attests the letter existed prior to that block.</p>
+  <p id="ots-line">Bitcoin block <strong>915229</strong> attests the letter existed prior to that block.</p>
 </section>
 <!-- OTS-END -->


### PR DESCRIPTION
## Summary
- decode docs/index.html via the contents API so the precheck can spot the published Bitcoin block status
- trigger the workflow on docs/letter.md updates instead of the nonexistent docs/letter.md.asc file

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68d1d12d382c8330ab99260a616bb9cb