### PR TITLE
Fix ots-upgrade scheduled runs after proof finalization

### DIFF
--- a/.github/workflows/ots-upgrade.yml
+++ b/.github/workflows/ots-upgrade.yml
@@ -29,51 +29,48 @@ jobs:
     steps:
       - name: Determine whether scheduled run should proceed
         id: decision
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const eventName = context.eventName;
-            if (eventName !== 'schedule') {
-              core.info(`Event "${eventName}" is not schedule; proceeding.`);
-              core.setOutput('should_run', 'true');
-              return;
-            }
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          REF: ${{ github.ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
 
-            const { owner, repo } = context.repo;
-            const refFromContext = context.ref ? context.ref.replace(/^refs\/heads\//, '') : null;
-            const fallbackRef = context.payload?.repository?.default_branch || 'main';
-            const ref = refFromContext || fallbackRef;
+          if [[ "${EVENT_NAME}" != "schedule" ]]; then
+            echo "Event '${EVENT_NAME}' is not schedule; proceeding."
+            printf 'should_run=%s\n' 'true' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
-            try {
-              const response = await github.repos.getContent({
-                owner,
-                repo,
-                path: 'docs/index.html',
-                ref,
-              });
+          branch="${REF_NAME:-}"
+          if [[ -z "$branch" && -n "${REF:-}" ]]; then
+            branch="${REF#refs/heads/}"
+          fi
+          if [[ -z "$branch" && -n "${DEFAULT_BRANCH:-}" ]]; then
+            branch="$DEFAULT_BRANCH"
+          fi
+          if [[ -z "$branch" ]]; then
+            branch="main"
+          fi
 
-              const data = response.data;
-              if (!data || data.type !== 'file') {
-                core.info('docs/index.html not found as a file; proceeding.');
-                core.setOutput('should_run', 'true');
-                return;
-              }
+          raw_url="https://raw.githubusercontent.com/${REPOSITORY}/${branch}/docs/index.html"
+          echo "Fetching ${raw_url} ..."
+          if ! content="$(curl -fsSL "$raw_url")"; then
+            echo "Unable to fetch docs/index.html from ${raw_url}; proceeding."
+            printf 'should_run=%s\n' 'true' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
-              const buffer = Buffer.from(data.content, data.encoding || 'base64');
-              const content = buffer.toString('utf8');
-              if (/Bitcoin block <strong>[0-9]+/.test(content)) {
-                core.info('Detected finalized Bitcoin block in docs/index.html; skipping scheduled run.');
-                core.setOutput('should_run', 'false');
-                return;
-              }
-            } catch (error) {
-              core.warning(`Unable to inspect docs/index.html for schedule precheck: ${error.message || error}`);
-              core.setOutput('should_run', 'true');
-              return;
-            }
-
-            core.info('No finalized Bitcoin block detected; proceeding.');
-            core.setOutput('should_run', 'true');
+          if echo "$content" | grep -Eq 'Bitcoin block <strong>[0-9]+'; then
+            echo "Detected finalized Bitcoin block in docs/index.html; skipping scheduled run."
+            printf 'should_run=%s\n' 'false' >> "$GITHUB_OUTPUT"
+          else
+            echo "No finalized Bitcoin block detected; proceeding."
+            printf 'should_run=%s\n' 'true' >> "$GITHUB_OUTPUT"
+          fi
 
   upgrade-and-update:
     needs: precheck


### PR DESCRIPTION
## Summary
- replace the GitHub Script precheck in ots-upgrade with a bash+curl check
- stop scheduled runs once docs/index.html already advertises a finalized Bitcoin block

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d35f41083c8330ac9b86d3783561ef