### PR TITLE
chore(ci): gate ots upgrade on current proof height

### DIFF
--- a/.github/workflows/ots-upgrade.yml
+++ b/.github/workflows/ots-upgrade.yml
@@ -45,32 +45,193 @@ jobs:
             exit 0
           fi
 
-          branch="${REF_NAME:-}"
-          if [[ -z "$branch" && -n "${REF:-}" ]]; then
-            branch="${REF#refs/heads/}"
-          fi
-          if [[ -z "$branch" && -n "${DEFAULT_BRANCH:-}" ]]; then
-            branch="$DEFAULT_BRANCH"
-          fi
-          if [[ -z "$branch" ]]; then
-            branch="main"
-          fi
+          python - <<'PY'
+import io
+import json
+import os
+import re
+import subprocess
+import sys
+from urllib.error import URLError, HTTPError
+from urllib.request import urlopen
 
-          raw_url="https://raw.githubusercontent.com/${REPOSITORY}/${branch}/docs/index.html"
-          echo "Fetching ${raw_url} ..."
-          if ! content="$(curl -fsSL "$raw_url")"; then
-            echo "Unable to fetch docs/index.html from ${raw_url}; proceeding."
-            printf 'should_run=%s\n' 'true' >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
 
-          if echo "$content" | grep -Eq 'Bitcoin block <strong>[0-9]+'; then
-            echo "Detected finalized Bitcoin block in docs/index.html; skipping scheduled run."
-            printf 'should_run=%s\n' 'false' >> "$GITHUB_OUTPUT"
-          else
-            echo "No finalized Bitcoin block detected; proceeding."
-            printf 'should_run=%s\n' 'true' >> "$GITHUB_OUTPUT"
-          fi
+def log(msg: str) -> None:
+    print(msg)
+
+
+def determine_branch() -> str:
+    branch = os.environ.get("REF_NAME")
+    ref = os.environ.get("REF", "")
+    default = os.environ.get("DEFAULT_BRANCH")
+
+    if not branch and ref.startswith("refs/heads/"):
+        branch = ref.split("/", 2)[-1]
+    if not branch and default:
+        branch = default
+    if not branch:
+        branch = "main"
+    return branch
+
+
+def fetch_text(url: str) -> str | None:
+    log(f"Fetching {url} ...")
+    try:
+        with urlopen(url) as resp:
+            return resp.read().decode("utf-8", "replace")
+    except (URLError, HTTPError) as exc:
+        log(f"Failed to fetch {url}: {exc}")
+        return None
+
+
+def fetch_bytes(url: str) -> bytes | None:
+    log(f"Fetching {url} (binary) ...")
+    try:
+        with urlopen(url) as resp:
+            return resp.read()
+    except (URLError, HTTPError) as exc:
+        log(f"Failed to fetch {url}: {exc}")
+        return None
+
+
+def ensure_opentimestamps() -> bool:
+    try:
+        import opentimestamps  # type: ignore  # noqa: F401
+        return True
+    except ImportError:
+        log("Installing opentimestamps-client for block height extraction ...")
+        try:
+            subprocess.run(
+                [sys.executable, "-m", "pip", "install", "--quiet", "opentimestamps-client"],
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except Exception as exc:  # pragma: no cover - best-effort installer
+            log(f"pip install failed: {exc}")
+            return False
+    try:
+        import opentimestamps  # type: ignore  # noqa: F401
+        return True
+    except ImportError:
+        log("Unable to import opentimestamps after installation attempt.")
+        return False
+
+
+def extract_ots_height(data: bytes) -> str:
+    if not data:
+        return ""
+    if not ensure_opentimestamps():
+        return ""
+    try:
+        from opentimestamps.core.serialize import StreamDeserializationContext
+        from opentimestamps.core.timestamp import DetachedTimestampFile
+        from opentimestamps.core.notary import BitcoinBlockHeaderAttestation
+    except Exception as exc:  # pragma: no cover - depends on package internals
+        log(f"Unable to import OpenTimestamps parser: {exc}")
+        return ""
+
+    try:
+        ctx = StreamDeserializationContext(io.BytesIO(data))
+        timestamp = DetachedTimestampFile.deserialize(ctx).timestamp
+    except Exception as exc:  # pragma: no cover - invalid proof
+        log(f"Failed to parse OTS proof: {exc}")
+        return ""
+
+    heights = sorted({
+        att.height
+        for _path, att in timestamp.all_attestations()
+        if isinstance(att, BitcoinBlockHeaderAttestation)
+    })
+    if not heights:
+        return ""
+    return str(heights[-1])
+
+
+def write_output(value: bool) -> None:
+    out_path = os.environ.get("GITHUB_OUTPUT")
+    if not out_path:
+        return
+    with open(out_path, "a", encoding="utf-8") as fh:
+        fh.write(f"should_run={'true' if value else 'false'}\n")
+
+
+def main() -> int:
+    repository = os.environ["REPOSITORY"]
+    branch = determine_branch()
+
+    base = f"https://raw.githubusercontent.com/{repository}/{branch}"
+
+    index_html = fetch_text(f"{base}/docs/index.html")
+    if index_html is None:
+        log("Unable to inspect docs/index.html; allowing workflow to proceed.")
+        write_output(True)
+        return 0
+
+    version_match = re.search(r"<!--\s*release-version:\s*v?([0-9][0-9.]+)\s*-->", index_html)
+    index_version = version_match.group(1) if version_match else ""
+    height_match = re.search(r"Bitcoin block <strong>([0-9]+)</strong>", index_html)
+    index_height = height_match.group(1) if height_match else ""
+
+    releases_raw = fetch_text(f"{base}/letter/RELEASES.json")
+    if releases_raw is None:
+        log("Unable to inspect RELEASES.json; allowing workflow to proceed.")
+        write_output(True)
+        return 0
+
+    try:
+        releases = json.loads(releases_raw)
+    except json.JSONDecodeError as exc:
+        log(f"Failed to parse RELEASES.json: {exc}")
+        write_output(True)
+        return 0
+
+    release_entry = None
+    releases_list = releases.get("releases") or []
+    if index_version:
+        for candidate in releases_list:
+            if candidate.get("version") == index_version:
+                release_entry = candidate
+                break
+    if release_entry is None and releases_list:
+        release_entry = releases_list[0]
+
+    if release_entry is None:
+        log("No releases found; allowing workflow to proceed.")
+        write_output(True)
+        return 0
+
+    ots_path = (
+        release_entry.get("files", {})
+        .get("ots", {})
+        .get("path")
+    )
+    if not ots_path:
+        log("Latest release lacks an OTS proof path; allowing workflow to proceed.")
+        write_output(True)
+        return 0
+
+    ots_bytes = fetch_bytes(f"{base}/{ots_path}")
+    ots_height = extract_ots_height(ots_bytes or b"")
+
+    if ots_height and index_height == ots_height:
+        log(
+            f"Detected finalized Bitcoin block {index_height} for current letter; skipping scheduled run."
+        )
+        write_output(False)
+        return 0
+
+    log(
+        "Proof not yet finalized for current letter (index height: "
+        f"{index_height or 'n/a'}, proof height: {ots_height or 'n/a'}); proceeding."
+    )
+    write_output(True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+PY
 
   upgrade-and-update:
     needs: precheck


### PR DESCRIPTION
## Summary
- replace the cron precheck with a Python gate that compares the published block height against the latest OTS proof
- install the OpenTimestamps client on demand so scheduled runs continue until the current letter’s proof is finalized

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d39f09d9108330901bfb201c05affa