### PR TITLE
Fix Python compatibility in ots-upgrade precheck script

### DIFF
--- a/.github/workflows/ots-upgrade.yml
+++ b/.github/workflows/ots-upgrade.yml
@@ -52,6 +52,7 @@ jobs:
           import re
           import subprocess
           import sys
+          from typing import Optional
           from urllib.error import URLError, HTTPError
           from urllib.request import urlopen
           
@@ -74,7 +75,7 @@ jobs:
               return branch
           
           
-          def fetch_text(url: str) -> str | None:
+          def fetch_text(url: str) -> Optional[str]:
               log(f"Fetching {url} ...")
               try:
                   with urlopen(url) as resp:
@@ -84,7 +85,7 @@ jobs:
                   return None
           
           
-          def fetch_bytes(url: str) -> bytes | None:
+          def fetch_bytes(url: str) -> Optional[bytes]:
               log(f"Fetching {url} (binary) ...")
               try:
                   with urlopen(url) as resp:


### PR DESCRIPTION
## Summary
- update the ots-upgrade precheck Python snippet to import Optional from typing
- replace Python 3.10 union annotations with Optional to avoid syntax errors on older interpreters

## Testing
- python scripts/release.py --check

------
https://chatgpt.com/codex/tasks/task_e_68d75c83abd8833082e98e1febd315cb