### PR TITLE
Fix Python 3.9 syntax compatibility in release scripts

### DIFF
--- a/letter/RELEASES.json
+++ b/letter/RELEASES.json
@@ -1,6 +1,6 @@
 {
   "schema": "asi-letter/releases#2",
-  "updated": "2025-09-20T03:49:17Z",
+  "updated": "2025-09-27T03:53:03Z",
   "key": {
     "fingerprint_current": "2C101FA70F42F93052F82FC755387365B7949796",
     "path": "keys/alice-asi-publickey.asc"
@@ -25,8 +25,8 @@
         },
         "ots": {
           "path": "letter/ASI-Letter-v2025.09.17.md.asc.ots",
-          "size": 2736,
-          "sha256": "aaa19499a956a425efcda1a42997303de0d45e70be4c082e153b94fa1154ff59",
+          "size": 4877,
+          "sha256": "fb11ce1ac0a24031334c1e60d049c1646c73e58052d60ff893769a789ad6ccfd",
           "encoding": "binary"
         }
       }

--- a/scripts/find_latest_ots.py
+++ b/scripts/find_latest_ots.py
@@ -7,7 +7,7 @@ import argparse
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, List
+from typing import Iterable, List, Optional, Tuple
 
 
 @dataclass(frozen=True)
@@ -26,12 +26,12 @@ def _candidate_files(directory: Path) -> Iterable[Path]:
             yield entry
 
 
-def _sort_key(path: Path) -> tuple[float, str]:
+def _sort_key(path: Path) -> Tuple[float, str]:
     stat = path.stat()
     return stat.st_mtime, path.name
 
 
-def _derive_version_components(path: Path) -> tuple[str, str, str]:
+def _derive_version_components(path: Path) -> Tuple[str, str, str]:
     basename = path.name
     noext = basename[: -len(path.suffix)] if path.suffix else basename
     version = noext
@@ -62,7 +62,7 @@ def find_latest_ots(directory: Path) -> LatestOts:
     return LatestOts(path=latest.resolve(), basename=basename, noext=noext, version=version)
 
 
-def _format_outputs(latest: LatestOts, *, base_dir: Path | None = None) -> List[str]:
+def _format_outputs(latest: LatestOts, *, base_dir: Optional[Path] = None) -> List[str]:
     cwd = base_dir or Path.cwd()
     try:
         rel_path = latest.path.relative_to(cwd)
@@ -77,7 +77,7 @@ def _format_outputs(latest: LatestOts, *, base_dir: Path | None = None) -> List[
     ]
 
 
-def main(argv: list[str] | None = None) -> int:
+def main(argv: Optional[List[str]] = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "directory",

--- a/scripts/gen_releases_manifest.py
+++ b/scripts/gen_releases_manifest.py
@@ -246,7 +246,7 @@ def _equivalent_without_updated(
     return proposed_copy == existing_copy
 
 
-def main(argv: Iterable[str] | None = None) -> int:
+def main(argv: Optional[Iterable[str]] = None) -> int:
     if argv is None:
         argv = sys.argv[1:]
     args = parse_args(argv)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -14,7 +14,7 @@ import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, List
+from typing import Iterable, List, Optional
 
 
 @dataclass(frozen=True)
@@ -89,7 +89,7 @@ def run_stage(stage: Stage, base_dir: Path, check_mode: bool) -> None:
     subprocess.run(cmd, check=True, cwd=base_dir)
 
 
-def main(argv: Iterable[str] | None = None) -> int:
+def main(argv: Optional[Iterable[str]] = None) -> int:
     if argv is None:
         argv = sys.argv[1:]
     args = parse_args(argv)

--- a/scripts/sync_docs_with_latest.py
+++ b/scripts/sync_docs_with_latest.py
@@ -7,7 +7,7 @@ import argparse
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Tuple
+from typing import Iterable, List, Optional, Tuple
 
 
 @dataclass(frozen=True)
@@ -40,7 +40,7 @@ def parse_args(argv: Iterable[str]) -> argparse.Namespace:
     return parser.parse_args(list(argv))
 
 
-def _parse_version(path: Path) -> Tuple[int, int, int] | None:
+def _parse_version(path: Path) -> Optional[Tuple[int, int, int]]:
     name = path.name
     if not name.startswith("ASI-Letter-v") or not name.endswith(".md"):
         return None
@@ -55,7 +55,7 @@ def _parse_version(path: Path) -> Tuple[int, int, int] | None:
 
 
 def discover_latest(letter_dir: Path) -> LetterRelease:
-    candidates: list[LetterRelease] = []
+    candidates: List[LetterRelease] = []
     for md_path in letter_dir.glob("ASI-Letter-v*.md"):
         version = _parse_version(md_path)
         if version is None:
@@ -97,7 +97,7 @@ def sync_latest(letter_dir: Path, docs_dir: Path, check_only: bool) -> bool:
     return _sync(release.source_md, md_dest)
 
 
-def main(argv: Iterable[str] | None = None) -> int:
+def main(argv: Optional[Iterable[str]] = None) -> int:
     if argv is None:
         argv = sys.argv[1:]
     args = parse_args(argv)


### PR DESCRIPTION
## Summary
- replace Python 3.10+ union syntax in release helper scripts with typing.Optional for compatibility with older interpreters
- switch to typing.Tuple and typing.List annotations where needed to avoid newer syntax usage

## Testing
- python -m compileall scripts

------
https://chatgpt.com/codex/tasks/task_e_68d75c83abd8833082e98e1febd315cb