### PR TITLE
Fix Python 3.9 compatibility in ots-upgrade workflow precheck

### DIFF
--- a/.github/workflows/ots-upgrade.yml
+++ b/.github/workflows/ots-upgrade.yml
@@ -74,7 +74,10 @@ jobs:
               return branch
           
           
-          def fetch_text(url: str) -> str | None:
+          from typing import Optional
+
+
+          def fetch_text(url: str) -> Optional[str]:
               log(f"Fetching {url} ...")
               try:
                   with urlopen(url) as resp:
@@ -84,7 +87,7 @@ jobs:
                   return None
           
           
-          def fetch_bytes(url: str) -> bytes | None:
+          def fetch_bytes(url: str) -> Optional[bytes]:
               log(f"Fetching {url} (binary) ...")
               try:
                   with urlopen(url) as resp:


### PR DESCRIPTION
## Summary
- replace Python 3.10 style union annotations in the ots-upgrade precheck script with Optional from typing
- ensure the inline workflow script executes on runners that default to Python 3.9

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d7604caa608330b27c4703bc6c182e