### PR TITLE
Fix unterminated docstring in update_version_metadata

### DIFF
--- a/scripts/update_version_metadata.py
+++ b/scripts/update_version_metadata.py
@@ -5,8 +5,7 @@ This script reads ``letter/RELEASES.json`` to locate the most recent release
 and then updates known metadata placeholders (page title, data attributes,
 comments, etc.) so they always reflect the latest signed version. Run this
 before publishing the static site to avoid drift between the manifest and the
-rendered HTML.
-"""
+rendered HTML."""
 from __future__ import annotations
 
 import argparse


### PR DESCRIPTION
## Summary
- close the module docstring in `scripts/update_version_metadata.py` to restore valid Python syntax

## Testing
- python3 -m compileall scripts

------
https://chatgpt.com/codex/tasks/task_e_68d7619dccc08330bcebf113e5cd63fa