### PR TITLE
Fix ots-upgrade workflow inline Python indentation

### DIFF
--- a/.github/workflows/ots-upgrade.yml
+++ b/.github/workflows/ots-upgrade.yml
@@ -264,40 +264,41 @@ jobs:
           TARGET=""
 
           if [[ -f letter/RELEASES.json ]]; then
-            TARGET="$(python - <<'PY'
-import json
-from pathlib import Path
+            TARGET="$(
+              python - <<'PY'
+              import json
+              from pathlib import Path
 
 
-def main() -> None:
-    try:
-        with Path('letter/RELEASES.json').open('r', encoding='utf-8') as fh:
-            payload = json.load(fh)
-    except Exception:
-        return
+              def main() -> None:
+                  try:
+                      with Path('letter/RELEASES.json').open('r', encoding='utf-8') as fh:
+                          payload = json.load(fh)
+                  except Exception:
+                      return
 
-    releases = payload.get('releases') or []
-    if not releases:
-        return
+                  releases = payload.get('releases') or []
+                  if not releases:
+                      return
 
-    latest = releases[0] or {}
-    path = (
-        (latest.get('files') or {})
-        .get('asc')
-        or {}
-    ).get('path')
-    if not path:
-        return
+                  latest = releases[0] or {}
+                  path = (
+                      (latest.get('files') or {})
+                      .get('asc')
+                      or {}
+                  ).get('path')
+                  if not path:
+                      return
 
-    resolved = Path(path)
-    if resolved.is_file():
-        print(resolved.as_posix())
+                  resolved = Path(path)
+                  if resolved.is_file():
+                      print(resolved.as_posix())
 
 
-if __name__ == '__main__':
-    main()
-PY
-)"
+              if __name__ == '__main__':
+                  main()
+              PY
+            )"
           fi
 
           if [[ -z "$TARGET" ]] && ls letter/*.asc 1>/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- indent the inline Python heredoc in the ots-upgrade workflow so the YAML parser accepts it

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d7619dccc08330bcebf113e5cd63fa