### PR TITLE
Fix ots-upgrade auto-commit to include upgraded proofs

### DIFF
--- a/.github/workflows/ots-upgrade.yml
+++ b/.github/workflows/ots-upgrade.yml
@@ -394,5 +394,8 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "chore(ots): upgrade proof + refresh status [ots-upgrade-auto]"
-          file_pattern: docs/index.html
+          file_pattern: |
+            docs/index.html
+            letter/*.ots
+            docs/*.ots
 


### PR DESCRIPTION
## Summary
- ensure the ots-upgrade workflow commits refreshed proofs alongside the status footer

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68d763ffec5c8330a1b5b2934fcefed1