### PR TITLE
Handle transient ots stamp failures in ots-upgrade workflow

### DIFF
--- a/.github/workflows/ots-upgrade.yml
+++ b/.github/workflows/ots-upgrade.yml
@@ -313,7 +313,11 @@ jobs:
             echo "Using TARGET='$TARGET'"
             if [[ ! -f "${TARGET}.ots" ]]; then
               echo "No .ots present; stamping"
-              ots stamp "$TARGET"
+              if ots stamp "$TARGET"; then
+                echo "Stamp completed"
+              else
+                echo "Warning: ots stamp failed; continuing without a freshly stamped proof" >&2
+              fi
             else
               echo "Found ${TARGET}.ots; skipping stamp."
             fi


### PR DESCRIPTION
## Summary
- allow the ots-upgrade workflow to continue if `ots stamp` fails so transient outages do not abort the job
- log a warning when stamping fails while keeping the rest of the upgrade logic intact

## Testing
- python3 scripts/release.py --check

------
https://chatgpt.com/codex/tasks/task_e_68d82c239b448330a960c07d1bbaee8a