### PR TITLE
Fix heredoc indentation in ots-upgrade workflow

### DIFF
--- a/.github/workflows/ots-upgrade.yml
+++ b/.github/workflows/ots-upgrade.yml
@@ -266,37 +266,37 @@ jobs:
           if [[ -f letter/RELEASES.json ]]; then
             TARGET="$(
               python - <<'PY'
-import json
-from pathlib import Path
+              import json
+              from pathlib import Path
 
 
-def main() -> None:
-    try:
-        with Path('letter/RELEASES.json').open('r', encoding='utf-8') as fh:
-            payload = json.load(fh)
-    except Exception:
-        return
+              def main() -> None:
+                  try:
+                      with Path('letter/RELEASES.json').open('r', encoding='utf-8') as fh:
+                          payload = json.load(fh)
+                  except Exception:
+                      return
 
-    releases = payload.get('releases') or []
-    if not releases:
-        return
+                  releases = payload.get('releases') or []
+                  if not releases:
+                      return
 
-    latest = releases[0] or {}
-    path = (
-        (latest.get('files') or {})
-        .get('asc')
-        or {}
-    ).get('path')
-    if not path:
-        return
+                  latest = releases[0] or {}
+                  path = (
+                      (latest.get('files') or {})
+                      .get('asc')
+                      or {}
+                  ).get('path')
+                  if not path:
+                      return
 
-    resolved = Path(path)
-    if resolved.is_file():
-        print(resolved.as_posix())
+                  resolved = Path(path)
+                  if resolved.is_file():
+                      print(resolved.as_posix())
 
 
-if __name__ == '__main__':
-    main()
+              if __name__ == '__main__':
+                  main()
               PY
             )"
           fi


### PR DESCRIPTION
## Summary
- fix the YAML literal indentation for the embedded Python helper inside ots-upgrade
- ensure the heredoc block stays nested within the shell run script so GitHub parses the workflow

## Testing
- python - <<'PY'
import yaml
from pathlib import Path
path = Path('.github/workflows/ots-upgrade.yml')
with path.open() as fh:
    yaml.safe_load(fh)
print('YAML OK')
PY
- python -m compileall scripts .github/scripts

------
https://chatgpt.com/codex/tasks/task_e_68d85193878483308723c0c1697d93fd