### PR TITLE
Fix ots-upgrade inline python indentation failure

### DIFF
--- a/.github/scripts/get_latest_letter_asc.py
+++ b/.github/scripts/get_latest_letter_asc.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Select the most recent letter .asc path from RELEASES.json."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Iterable, Optional
+
+
+def iter_candidates(path_value: str, manifest_path: Path) -> Iterable[Path]:
+    """Yield likely filesystem locations for the manifest-provided path."""
+
+    raw = Path(path_value)
+    if raw.is_absolute():
+        yield raw
+        return
+
+    # Prefer interpreting the value relative to the current working directory.
+    yield raw
+
+    # Some manifests may use paths relative to the manifest's own directory.
+    yield manifest_path.parent / raw
+
+
+def find_latest_letter_asc(manifest_path: Path) -> Optional[Path]:
+    if not manifest_path.is_file():
+        return None
+
+    try:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+    releases = payload.get("releases") or []
+    if not releases:
+        return None
+
+    latest = releases[0] or {}
+    asc_info = (latest.get("files") or {}).get("asc") or {}
+    path_value = asc_info.get("path")
+    if not path_value:
+        return None
+
+    for candidate in iter_candidates(path_value, manifest_path):
+        try:
+            resolved = candidate.resolve(strict=True)
+        except FileNotFoundError:
+            continue
+        if resolved.is_file():
+            return resolved
+    return None
+
+
+def main() -> int:
+    manifest_arg = sys.argv[1] if len(sys.argv) > 1 else "letter/RELEASES.json"
+    manifest_path = Path(manifest_arg)
+
+    result = find_latest_letter_asc(manifest_path)
+    if result is None:
+        return 0
+
+    cwd = Path.cwd().resolve()
+    try:
+        display = result.relative_to(cwd)
+    except ValueError:
+        display = result
+
+    sys.stdout.write(display.as_posix())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/ots-upgrade.yml
+++ b/.github/workflows/ots-upgrade.yml
@@ -264,41 +264,7 @@ jobs:
           TARGET=""
 
           if [[ -f letter/RELEASES.json ]]; then
-            TARGET="$(
-              python - <<'PY'
-              import json
-              from pathlib import Path
-
-
-              def main() -> None:
-                  try:
-                      with Path('letter/RELEASES.json').open('r', encoding='utf-8') as fh:
-                          payload = json.load(fh)
-                  except Exception:
-                      return
-
-                  releases = payload.get('releases') or []
-                  if not releases:
-                      return
-
-                  latest = releases[0] or {}
-                  path = (
-                      (latest.get('files') or {})
-                      .get('asc')
-                      or {}
-                  ).get('path')
-                  if not path:
-                      return
-
-                  resolved = Path(path)
-                  if resolved.is_file():
-                      print(resolved.as_posix())
-
-
-              if __name__ == '__main__':
-                  main()
-              PY
-            )"
+            TARGET="$(python .github/scripts/get_latest_letter_asc.py 2>/dev/null || true)"
           fi
 
           if [[ -n "$TARGET" ]]; then


### PR DESCRIPTION
## Summary
- add `.github/scripts/get_latest_letter_asc.py` to safely resolve the newest letter `.asc` path from the manifest
- update the ots-upgrade workflow to call the helper instead of an inline heredoc python snippet, avoiding indentation errors on runners

## Testing
- python .github/scripts/get_latest_letter_asc.py
- bash /tmp/prepare.sh

------
https://chatgpt.com/codex/tasks/task_e_68d85a15a424833087570d73495f2997