### PR TITLE
Stop ots-upgrade after proof finalization

### DIFF
--- a/.github/workflows/ots-upgrade.yml
+++ b/.github/workflows/ots-upgrade.yml
@@ -27,7 +27,7 @@ jobs:
     outputs:
       should_run: ${{ steps.decision.outputs.should_run }}
     steps:
-      - name: Determine whether scheduled run should proceed
+      - name: Determine whether workflow should proceed
         id: decision
         shell: bash
         env:
@@ -38,12 +38,6 @@ jobs:
           REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
-
-          if [[ "${EVENT_NAME}" != "schedule" ]]; then
-            echo "Event '${EVENT_NAME}' is not schedule; proceeding."
-            printf 'should_run=%s\n' 'true' >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
 
           python - <<'PY'
           import io
@@ -160,9 +154,15 @@ jobs:
           
           
           def main() -> int:
+              event_name = os.environ.get("EVENT_NAME", "")
+              if event_name == "workflow_dispatch":
+                  log("Manual dispatch requested; allowing workflow to proceed.")
+                  write_output(True)
+                  return 0
+
               repository = os.environ["REPOSITORY"]
               branch = determine_branch()
-          
+
               base = f"https://raw.githubusercontent.com/{repository}/{branch}"
           
               index_html = fetch_text(f"{base}/docs/index.html")
@@ -219,11 +219,11 @@ jobs:
           
               if ots_height and index_height == ots_height:
                   log(
-                      f"Detected finalized Bitcoin block {index_height} for current letter; skipping scheduled run."
+                      f"Detected finalized Bitcoin block {index_height} for current letter; skipping event '{event_name or 'unknown'}'."
                   )
                   write_output(False)
                   return 0
-          
+
               log(
                   "Proof not yet finalized for current letter (index height: "
                   f"{index_height or 'n/a'}, proof height: {ots_height or 'n/a'}); proceeding."


### PR DESCRIPTION
## Summary
- run the ots-upgrade precheck for every trigger instead of only scheduled runs
- skip the workflow whenever docs/index.html already shows the finalized block height
- keep manual dispatches available for on-demand proof refreshes

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d940ffb9b483309894e3663b3a20bb