### PR TITLE
Pause scheduled ots-upgrade runs when proof is final

### DIFF
--- a/.github/workflows/ots-upgrade.yml
+++ b/.github/workflows/ots-upgrade.yml
@@ -19,13 +19,15 @@ concurrency:
 
 permissions:
   contents: write
-  actions: read
+  actions: write
 
 jobs:
   precheck:
+    if: ${{ github.event_name != 'schedule' || vars.OTS_UPGRADE_CRON_ENABLED != 'false' }}
     runs-on: ubuntu-latest
     outputs:
       should_run: ${{ steps.decision.outputs.should_run }}
+      cron_state: ${{ steps.decision.outputs.cron_state }}
     steps:
       - name: Determine whether workflow should proceed
         id: decision
@@ -145,30 +147,37 @@ jobs:
               return str(heights[-1])
           
           
-          def write_output(value: bool) -> None:
+          def write_output(name: str, value: str) -> None:
               out_path = os.environ.get("GITHUB_OUTPUT")
               if not out_path:
                   return
               with open(out_path, "a", encoding="utf-8") as fh:
-                  fh.write(f"should_run={'true' if value else 'false'}\n")
-          
-          
+                  fh.write(f"{name}={value}\n")
+
+
           def main() -> int:
               event_name = os.environ.get("EVENT_NAME", "")
+              cron_state = "none"
               if event_name == "workflow_dispatch":
                   log("Manual dispatch requested; allowing workflow to proceed.")
-                  write_output(True)
+                  write_output("should_run", "true")
+                  write_output("cron_state", cron_state)
                   return 0
 
               repository = os.environ["REPOSITORY"]
               branch = determine_branch()
 
               base = f"https://raw.githubusercontent.com/{repository}/{branch}"
-          
+
+              if event_name in {"push", "workflow_run"}:
+                  log("Detected content update event; ensuring cron schedule is enabled.")
+                  cron_state = "enable"
+
               index_html = fetch_text(f"{base}/docs/index.html")
               if index_html is None:
                   log("Unable to inspect docs/index.html; allowing workflow to proceed.")
-                  write_output(True)
+                  write_output("should_run", "true")
+                  write_output("cron_state", cron_state)
                   return 0
           
               version_match = re.search(r"<!--\s*release-version:\s*v?([0-9][0-9.]+)\s*-->", index_html)
@@ -179,14 +188,16 @@ jobs:
               releases_raw = fetch_text(f"{base}/letter/RELEASES.json")
               if releases_raw is None:
                   log("Unable to inspect RELEASES.json; allowing workflow to proceed.")
-                  write_output(True)
+                  write_output("should_run", "true")
+                  write_output("cron_state", cron_state)
                   return 0
           
               try:
                   releases = json.loads(releases_raw)
               except json.JSONDecodeError as exc:
                   log(f"Failed to parse RELEASES.json: {exc}")
-                  write_output(True)
+                  write_output("should_run", "true")
+                  write_output("cron_state", cron_state)
                   return 0
           
               release_entry = None
@@ -201,7 +212,8 @@ jobs:
           
               if release_entry is None:
                   log("No releases found; allowing workflow to proceed.")
-                  write_output(True)
+                  write_output("should_run", "true")
+                  write_output("cron_state", cron_state)
                   return 0
           
               ots_path = (
@@ -211,7 +223,8 @@ jobs:
               )
               if not ots_path:
                   log("Latest release lacks an OTS proof path; allowing workflow to proceed.")
-                  write_output(True)
+                  write_output("should_run", "true")
+                  write_output("cron_state", cron_state)
                   return 0
           
               ots_bytes = fetch_bytes(f"{base}/{ots_path}")
@@ -221,14 +234,18 @@ jobs:
                   log(
                       f"Detected finalized Bitcoin block {index_height} for current letter; skipping event '{event_name or 'unknown'}'."
                   )
-                  write_output(False)
+                  if event_name == "schedule":
+                      cron_state = "disable"
+                  write_output("should_run", "false")
+                  write_output("cron_state", cron_state)
                   return 0
 
               log(
                   "Proof not yet finalized for current letter (index height: "
                   f"{index_height or 'n/a'}, proof height: {ots_height or 'n/a'}); proceeding."
               )
-              write_output(True)
+              write_output("should_run", "true")
+              write_output("cron_state", cron_state)
               return 0
           
           
@@ -236,8 +253,40 @@ jobs:
               sys.exit(main())
           PY
 
-  upgrade-and-update:
+  manage-cron-flag:
     needs: precheck
+    if: ${{ needs.precheck.outputs.cron_state != 'none' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update cron toggle variable
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DESIRED: ${{ needs.precheck.outputs.cron_state }}
+        run: |
+          set -euo pipefail
+
+          repo="${GITHUB_REPOSITORY:-}"
+          if [[ -n "$repo" ]]; then
+            repo_args=(--repo "$repo")
+          else
+            repo_args=()
+          fi
+
+          case "$DESIRED" in
+            enable)
+              gh variable set OTS_UPGRADE_CRON_ENABLED --body true "${repo_args[@]}"
+              ;;
+            disable)
+              gh variable set OTS_UPGRADE_CRON_ENABLED --body false "${repo_args[@]}"
+              ;;
+            *)
+              echo "No cron toggle requested."
+              ;;
+          esac
+
+  upgrade-and-update:
+    needs:
+      - precheck
     if: ${{ (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success') && needs.precheck.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- gate the scheduled ots-upgrade job on a repository variable that can suspend cron invocations
- automatically toggle the variable off once the latest proof is finalized and back on when new letter content arrives

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68dc3278e7988330a75a1e206694a64a