### PR TITLE
fix(ci): honor ots pause state

### DIFF
--- a/.github/scripts/check_letter_finalization.py
+++ b/.github/scripts/check_letter_finalization.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Utility to determine whether the current letter's OTS proof has finalized."""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import re
+import subprocess
+import sys
+from typing import Optional
+from urllib.error import HTTPError, URLError
+from urllib.request import urlopen
+
+
+def log(message: str) -> None:
+    print(message)
+
+
+def determine_branch(ref_name: Optional[str], ref: Optional[str], default: Optional[str]) -> str:
+    branch = (ref_name or "").strip()
+    ref_value = (ref or "").strip()
+    default_value = (default or "").strip()
+
+    if not branch and ref_value.startswith("refs/heads/"):
+        branch = ref_value.split("/", 2)[-1]
+    if not branch and default_value:
+        branch = default_value
+    if not branch:
+        branch = "main"
+    return branch
+
+
+def fetch_text(url: str) -> Optional[str]:
+    log(f"Fetching {url} ...")
+    try:
+        with urlopen(url) as response:  # nosec: B310 - controlled URLs
+            return response.read().decode("utf-8", "replace")
+    except (URLError, HTTPError) as exc:
+        log(f"Failed to fetch {url}: {exc}")
+        return None
+
+
+def fetch_bytes(url: str) -> Optional[bytes]:
+    log(f"Fetching {url} (binary) ...")
+    try:
+        with urlopen(url) as response:  # nosec: B310 - controlled URLs
+            return response.read()
+    except (URLError, HTTPError) as exc:
+        log(f"Failed to fetch {url}: {exc}")
+        return None
+
+
+def ensure_opentimestamps() -> bool:
+    try:
+        import opentimestamps  # type: ignore  # noqa: F401
+        return True
+    except ImportError:
+        log("Installing opentimestamps-client for block height extraction ...")
+        try:
+            subprocess.run(
+                [sys.executable, "-m", "pip", "install", "--quiet", "opentimestamps-client"],
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except Exception as exc:  # pragma: no cover - best effort
+            log(f"pip install failed: {exc}")
+            return False
+
+    try:
+        import opentimestamps  # type: ignore  # noqa: F401
+        return True
+    except ImportError:
+        log("Unable to import opentimestamps after installation attempt.")
+        return False
+
+
+def extract_ots_height(data: Optional[bytes]) -> str:
+    if not data:
+        return ""
+    if not ensure_opentimestamps():
+        return ""
+
+    try:
+        from opentimestamps.core.serialize import StreamDeserializationContext
+        from opentimestamps.core.timestamp import DetachedTimestampFile
+        from opentimestamps.core.notary import BitcoinBlockHeaderAttestation
+    except Exception as exc:  # pragma: no cover - depends on package internals
+        log(f"Unable to import OpenTimestamps parser: {exc}")
+        return ""
+
+    try:
+        ctx = StreamDeserializationContext(io.BytesIO(data))
+        timestamp = DetachedTimestampFile.deserialize(ctx).timestamp
+    except Exception as exc:  # pragma: no cover - invalid proof
+        log(f"Failed to parse OTS proof: {exc}")
+        return ""
+
+    heights = sorted(
+        {
+            att.height
+            for _path, att in timestamp.all_attestations()
+            if isinstance(att, BitcoinBlockHeaderAttestation)
+        }
+    )
+    if not heights:
+        return ""
+    return str(heights[-1])
+
+
+def write_outputs(path: Optional[str], should_run: bool, index_height: str, proof_height: str) -> None:
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write(f"should_run={'true' if should_run else 'false'}\n")
+        if index_height:
+            handle.write(f"index_height={index_height}\n")
+        if proof_height:
+            handle.write(f"proof_height={proof_height}\n")
+
+
+def evaluate(
+    event_name: str,
+    repository: str,
+    branch: str,
+    force: bool = False,
+) -> tuple[bool, str, str]:
+    if force:
+        log("Force flag supplied; allowing workflow to proceed regardless of finalization status.")
+        return True, "", ""
+
+    base = f"https://raw.githubusercontent.com/{repository}/{branch}"
+
+    index_html = fetch_text(f"{base}/docs/index.html")
+    if index_html is None:
+        log("Unable to inspect docs/index.html; allowing workflow to proceed.")
+        return True, "", ""
+
+    version_match = re.search(r"<!--\s*release-version:\s*v?([0-9][0-9.]+)\s*-->", index_html)
+    index_version = version_match.group(1) if version_match else ""
+    height_match = re.search(r"Bitcoin block <strong>([0-9]+)</strong>", index_html)
+    index_height = height_match.group(1) if height_match else ""
+
+    releases_raw = fetch_text(f"{base}/letter/RELEASES.json")
+    if releases_raw is None:
+        log("Unable to inspect RELEASES.json; allowing workflow to proceed.")
+        return True, index_height, ""
+
+    try:
+        releases = json.loads(releases_raw)
+    except json.JSONDecodeError as exc:
+        log(f"Failed to parse RELEASES.json: {exc}")
+        return True, index_height, ""
+
+    release_entry = None
+    releases_list = releases.get("releases") or []
+    if index_version:
+        for candidate in releases_list:
+            if candidate.get("version") == index_version:
+                release_entry = candidate
+                break
+    if release_entry is None and releases_list:
+        release_entry = releases_list[0]
+
+    if release_entry is None:
+        log("No releases found; allowing workflow to proceed.")
+        return True, index_height, ""
+
+    ots_path = (
+        release_entry.get("files", {})
+        .get("ots", {})
+        .get("path")
+    )
+    if not ots_path:
+        log("Latest release lacks an OTS proof path; allowing workflow to proceed.")
+        return True, index_height, ""
+
+    ots_bytes = fetch_bytes(f"{base}/{ots_path}")
+    ots_height = extract_ots_height(ots_bytes)
+
+    if ots_height and index_height == ots_height:
+        log(
+            "Detected finalized Bitcoin block %s for current letter; skipping further runs." % index_height
+        )
+        return False, index_height, ots_height
+
+    log(
+        "Proof not yet finalized for current letter (index height: %s, proof height: %s); proceeding." % (
+            index_height or "n/a",
+            ots_height or "n/a",
+        )
+    )
+    return True, index_height, ots_height
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--event-name", default="", help="GitHub event name")
+    parser.add_argument("--repository", required=True, help="owner/repo slug")
+    parser.add_argument("--ref-name", default="", help="Git ref name")
+    parser.add_argument("--ref", default="", help="Full Git ref")
+    parser.add_argument("--default-branch", default="", help="Default branch name")
+    parser.add_argument("--github-output", default="", help="Path to GITHUB_OUTPUT")
+    parser.add_argument(
+        "--force",
+        choices={"true", "false"},
+        default="false",
+        help="Override the finalization guard (true/false)",
+    )
+
+    args = parser.parse_args()
+
+    branch = determine_branch(args.ref_name, args.ref, args.default_branch)
+
+    should_run, index_height, proof_height = evaluate(
+        args.event_name,
+        args.repository,
+        branch,
+        force=args.force == "true",
+    )
+    write_outputs(args.github_output, should_run, index_height, proof_height)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ots-upgrade-scheduler.yml
+++ b/.github/workflows/ots-upgrade-scheduler.yml
@@ -1,0 +1,56 @@
+name: ots-upgrade-scheduler
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  actions: read
+  workflows: write
+
+jobs:
+  maybe-trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Determine whether an update is still pending
+        id: decision
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          REF: ${{ github.ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          REPOSITORY: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          python .github/scripts/check_letter_finalization.py \
+            --event-name "$EVENT_NAME" \
+            --repository "$REPOSITORY" \
+            --ref-name "$REF_NAME" \
+            --ref "$REF" \
+            --default-branch "$DEFAULT_BRANCH" \
+            --force false \
+            --github-output "${GITHUB_OUTPUT:-}"
+
+      - name: Dispatch ots-upgrade workflow
+        if: steps.decision.outputs.should_run == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const rawRef = context.ref || `refs/heads/${context.payload?.repository?.default_branch || 'main'}`;
+            const branch = rawRef.replace(/^refs\/heads\//, '');
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'ots-upgrade.yml',
+              ref: branch,
+              inputs: { force: 'false' },
+            });

--- a/.github/workflows/ots-upgrade.yml
+++ b/.github/workflows/ots-upgrade.yml
@@ -1,8 +1,11 @@
 name: ots-upgrade
 on:
-  schedule:
-    - cron: "*/30 * * * *"
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Set to true to override the finalization guard"
+        required: false
+        default: "false"
   workflow_run:
     workflows:
       - releases-manifest
@@ -36,205 +39,18 @@ jobs:
           REF: ${{ github.ref }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           REPOSITORY: ${{ github.repository }}
+          FORCE: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.force == 'true') && 'true' || 'false' }}
         run: |
           set -euo pipefail
 
-          python - <<'PY'
-          import io
-          import json
-          import os
-          import re
-          import subprocess
-          import sys
-          from urllib.error import URLError, HTTPError
-          from urllib.request import urlopen
-          
-          
-          def log(msg: str) -> None:
-              print(msg)
-          
-          
-          def determine_branch() -> str:
-              branch = os.environ.get("REF_NAME")
-              ref = os.environ.get("REF", "")
-              default = os.environ.get("DEFAULT_BRANCH")
-          
-              if not branch and ref.startswith("refs/heads/"):
-                  branch = ref.split("/", 2)[-1]
-              if not branch and default:
-                  branch = default
-              if not branch:
-                  branch = "main"
-              return branch
-          
-          
-          from typing import Optional
-
-
-          def fetch_text(url: str) -> Optional[str]:
-              log(f"Fetching {url} ...")
-              try:
-                  with urlopen(url) as resp:
-                      return resp.read().decode("utf-8", "replace")
-              except (URLError, HTTPError) as exc:
-                  log(f"Failed to fetch {url}: {exc}")
-                  return None
-          
-          
-          def fetch_bytes(url: str) -> Optional[bytes]:
-              log(f"Fetching {url} (binary) ...")
-              try:
-                  with urlopen(url) as resp:
-                      return resp.read()
-              except (URLError, HTTPError) as exc:
-                  log(f"Failed to fetch {url}: {exc}")
-                  return None
-          
-          
-          def ensure_opentimestamps() -> bool:
-              try:
-                  import opentimestamps  # type: ignore  # noqa: F401
-                  return True
-              except ImportError:
-                  log("Installing opentimestamps-client for block height extraction ...")
-                  try:
-                      subprocess.run(
-                          [sys.executable, "-m", "pip", "install", "--quiet", "opentimestamps-client"],
-                          check=True,
-                          stdout=subprocess.DEVNULL,
-                          stderr=subprocess.DEVNULL,
-                      )
-                  except Exception as exc:  # pragma: no cover - best-effort installer
-                      log(f"pip install failed: {exc}")
-                      return False
-              try:
-                  import opentimestamps  # type: ignore  # noqa: F401
-                  return True
-              except ImportError:
-                  log("Unable to import opentimestamps after installation attempt.")
-                  return False
-          
-          
-          def extract_ots_height(data: bytes) -> str:
-              if not data:
-                  return ""
-              if not ensure_opentimestamps():
-                  return ""
-              try:
-                  from opentimestamps.core.serialize import StreamDeserializationContext
-                  from opentimestamps.core.timestamp import DetachedTimestampFile
-                  from opentimestamps.core.notary import BitcoinBlockHeaderAttestation
-              except Exception as exc:  # pragma: no cover - depends on package internals
-                  log(f"Unable to import OpenTimestamps parser: {exc}")
-                  return ""
-          
-              try:
-                  ctx = StreamDeserializationContext(io.BytesIO(data))
-                  timestamp = DetachedTimestampFile.deserialize(ctx).timestamp
-              except Exception as exc:  # pragma: no cover - invalid proof
-                  log(f"Failed to parse OTS proof: {exc}")
-                  return ""
-          
-              heights = sorted({
-                  att.height
-                  for _path, att in timestamp.all_attestations()
-                  if isinstance(att, BitcoinBlockHeaderAttestation)
-              })
-              if not heights:
-                  return ""
-              return str(heights[-1])
-          
-          
-          def write_output(value: bool) -> None:
-              out_path = os.environ.get("GITHUB_OUTPUT")
-              if not out_path:
-                  return
-              with open(out_path, "a", encoding="utf-8") as fh:
-                  fh.write(f"should_run={'true' if value else 'false'}\n")
-          
-          
-          def main() -> int:
-              event_name = os.environ.get("EVENT_NAME", "")
-              if event_name == "workflow_dispatch":
-                  log("Manual dispatch requested; allowing workflow to proceed.")
-                  write_output(True)
-                  return 0
-
-              repository = os.environ["REPOSITORY"]
-              branch = determine_branch()
-
-              base = f"https://raw.githubusercontent.com/{repository}/{branch}"
-          
-              index_html = fetch_text(f"{base}/docs/index.html")
-              if index_html is None:
-                  log("Unable to inspect docs/index.html; allowing workflow to proceed.")
-                  write_output(True)
-                  return 0
-          
-              version_match = re.search(r"<!--\s*release-version:\s*v?([0-9][0-9.]+)\s*-->", index_html)
-              index_version = version_match.group(1) if version_match else ""
-              height_match = re.search(r"Bitcoin block <strong>([0-9]+)</strong>", index_html)
-              index_height = height_match.group(1) if height_match else ""
-          
-              releases_raw = fetch_text(f"{base}/letter/RELEASES.json")
-              if releases_raw is None:
-                  log("Unable to inspect RELEASES.json; allowing workflow to proceed.")
-                  write_output(True)
-                  return 0
-          
-              try:
-                  releases = json.loads(releases_raw)
-              except json.JSONDecodeError as exc:
-                  log(f"Failed to parse RELEASES.json: {exc}")
-                  write_output(True)
-                  return 0
-          
-              release_entry = None
-              releases_list = releases.get("releases") or []
-              if index_version:
-                  for candidate in releases_list:
-                      if candidate.get("version") == index_version:
-                          release_entry = candidate
-                          break
-              if release_entry is None and releases_list:
-                  release_entry = releases_list[0]
-          
-              if release_entry is None:
-                  log("No releases found; allowing workflow to proceed.")
-                  write_output(True)
-                  return 0
-          
-              ots_path = (
-                  release_entry.get("files", {})
-                  .get("ots", {})
-                  .get("path")
-              )
-              if not ots_path:
-                  log("Latest release lacks an OTS proof path; allowing workflow to proceed.")
-                  write_output(True)
-                  return 0
-          
-              ots_bytes = fetch_bytes(f"{base}/{ots_path}")
-              ots_height = extract_ots_height(ots_bytes or b"")
-          
-              if ots_height and index_height == ots_height:
-                  log(
-                      f"Detected finalized Bitcoin block {index_height} for current letter; skipping event '{event_name or 'unknown'}'."
-                  )
-                  write_output(False)
-                  return 0
-
-              log(
-                  "Proof not yet finalized for current letter (index height: "
-                  f"{index_height or 'n/a'}, proof height: {ots_height or 'n/a'}); proceeding."
-              )
-              write_output(True)
-              return 0
-          
-          
-          if __name__ == "__main__":
-              sys.exit(main())
-          PY
+          python .github/scripts/check_letter_finalization.py \
+            --event-name "$EVENT_NAME" \
+            --repository "$REPOSITORY" \
+            --ref-name "$REF_NAME" \
+            --ref "$REF" \
+            --default-branch "$DEFAULT_BRANCH" \
+            --force "$FORCE" \
+            --github-output "${GITHUB_OUTPUT:-}"
 
   upgrade-and-update:
     needs: precheck


### PR DESCRIPTION
## Summary
- gate the OTS finalization helper behind an explicit `force` flag so automated dispatches respect the pause state
- expose a `force` input on the `ots-upgrade` workflow and ensure scheduler dispatches keep it disabled by default
- wire the scheduler and main workflow to pass the new flag to the shared finalization script

## Testing
- python -m compileall .github/scripts/check_letter_finalization.py

------
https://chatgpt.com/codex/tasks/task_e_68dc3278e7988330a75a1e206694a64a