### PR TITLE
Fix ots-upgrade cron toggle when proof finalized

### DIFF
--- a/.github/workflows/ots-upgrade.yml
+++ b/.github/workflows/ots-upgrade.yml
@@ -158,6 +158,8 @@ jobs:
           def main() -> int:
               event_name = os.environ.get("EVENT_NAME", "")
               cron_state = "none"
+              force_enable = event_name in {"push", "workflow_run"}
+              default_cron_state = "enable" if force_enable else "none"
               if event_name == "workflow_dispatch":
                   log("Manual dispatch requested; allowing workflow to proceed.")
                   write_output("should_run", "true")
@@ -169,15 +171,16 @@ jobs:
 
               base = f"https://raw.githubusercontent.com/{repository}/{branch}"
 
-              if event_name in {"push", "workflow_run"}:
-                  log("Detected content update event; ensuring cron schedule is enabled.")
-                  cron_state = "enable"
+              if force_enable:
+                  log(
+                      "Detected content update event; cron schedule will be re-enabled if work remains."
+                  )
 
               index_html = fetch_text(f"{base}/docs/index.html")
               if index_html is None:
                   log("Unable to inspect docs/index.html; allowing workflow to proceed.")
                   write_output("should_run", "true")
-                  write_output("cron_state", cron_state)
+                  write_output("cron_state", default_cron_state)
                   return 0
           
               version_match = re.search(r"<!--\s*release-version:\s*v?([0-9][0-9.]+)\s*-->", index_html)
@@ -189,15 +192,15 @@ jobs:
               if releases_raw is None:
                   log("Unable to inspect RELEASES.json; allowing workflow to proceed.")
                   write_output("should_run", "true")
-                  write_output("cron_state", cron_state)
+                  write_output("cron_state", default_cron_state)
                   return 0
-          
+
               try:
                   releases = json.loads(releases_raw)
               except json.JSONDecodeError as exc:
                   log(f"Failed to parse RELEASES.json: {exc}")
                   write_output("should_run", "true")
-                  write_output("cron_state", cron_state)
+                  write_output("cron_state", default_cron_state)
                   return 0
           
               release_entry = None
@@ -213,7 +216,7 @@ jobs:
               if release_entry is None:
                   log("No releases found; allowing workflow to proceed.")
                   write_output("should_run", "true")
-                  write_output("cron_state", cron_state)
+                  write_output("cron_state", default_cron_state)
                   return 0
           
               ots_path = (
@@ -224,7 +227,7 @@ jobs:
               if not ots_path:
                   log("Latest release lacks an OTS proof path; allowing workflow to proceed.")
                   write_output("should_run", "true")
-                  write_output("cron_state", cron_state)
+                  write_output("cron_state", default_cron_state)
                   return 0
           
               ots_bytes = fetch_bytes(f"{base}/{ots_path}")
@@ -236,6 +239,8 @@ jobs:
                   )
                   if event_name == "schedule":
                       cron_state = "disable"
+                  else:
+                      cron_state = "none"
                   write_output("should_run", "false")
                   write_output("cron_state", cron_state)
                   return 0
@@ -245,7 +250,7 @@ jobs:
                   f"{index_height or 'n/a'}, proof height: {ots_height or 'n/a'}); proceeding."
               )
               write_output("should_run", "true")
-              write_output("cron_state", cron_state)
+              write_output("cron_state", default_cron_state)
               return 0
           
           


### PR DESCRIPTION
## Summary
- ensure the ots-upgrade precheck no longer re-enables the cron schedule after the proof has finalized
- reuse the default cron toggle handling for all fallback code paths so pushes only enable the schedule when work remains

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68e5ee6b75c88330b617f08bde099fe6