### PR TITLE
Optimize auto-release trigger to avoid redundant workflow runs

### DIFF
--- a/.github/workflows/auto-release-latest-letter.yml
+++ b/.github/workflows/auto-release-latest-letter.yml
@@ -12,16 +12,10 @@ on:
       - "README.md"
       - "LICENSE"
       - "LICENSE-DOCS"
-  # Commits made by Actions (GITHUB_TOKEN) don't trigger push events, so we
-  # listen for the final workflow in the chain (ots-upgrade) to avoid redundant
-  # runs.  Previously this also listed releases-manifest, but since ots-upgrade
-  # is triggered by releases-manifest, that caused auto-release to fire twice
-  # per release (once for the intermediate step, once for the final step).
-  workflow_run:
-    workflows:
-      - ots-upgrade
-    types:
-      - completed
+  # ots-upgrade explicitly dispatches this workflow (via `gh workflow run`) only
+  # when it actually commits changes, so we no longer need a blanket
+  # workflow_run trigger that fired on every ots-upgrade completion — including
+  # the frequent scheduled checks that found nothing to do.
   workflow_dispatch: {}
 
 permissions:
@@ -29,10 +23,7 @@ permissions:
 
 jobs:
   release:
-    # Only run on successful upstream workflow completions (or push / manual triggers).
-    if: >-
-      github.event_name != 'workflow_run'
-      || github.event.workflow_run.conclusion == 'success'
+    # Runs on push (non-letter paths), or workflow_dispatch (manual / from ots-upgrade).
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/ots-upgrade.yml
+++ b/.github/workflows/ots-upgrade.yml
@@ -484,6 +484,7 @@ jobs:
           python3 scripts/release.py --skip-sync
 
       - name: Commit upgraded proof and refreshed footer
+        id: auto-commit
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "chore(ots): upgrade proof + refresh status"
@@ -492,3 +493,9 @@ jobs:
             docs/letter.md
             letter/RELEASES.json
             letter/*.ots
+
+      - name: Trigger auto-release (only when changes were committed)
+        if: steps.auto-commit.outputs.changes_detected == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run auto-release-latest-letter.yml --repo "${{ github.repository }}"


### PR DESCRIPTION
## Summary
This change optimizes the auto-release workflow trigger mechanism to eliminate redundant runs by having `ots-upgrade` explicitly dispatch the auto-release workflow only when it actually commits changes, rather than relying on a blanket `workflow_run` trigger that fired on every completion.

## Key Changes
- **auto-release-latest-letter.yml**: Removed the `workflow_run` trigger that listened for `ots-upgrade` completions and replaced it with reliance on explicit `workflow_dispatch` calls. Simplified the job condition since we no longer need to check for successful upstream workflow completion.
- **ots-upgrade.yml**: Added an `id` to the git-auto-commit step to capture its outputs, then added a new step that explicitly triggers the auto-release workflow using `gh workflow run` only when changes were actually detected and committed.

## Implementation Details
- The auto-commit step now has `id: auto-commit` to expose its `changes_detected` output
- The new trigger step uses the condition `if: steps.auto-commit.outputs.changes_detected == 'true'` to ensure auto-release only runs when there are actual changes to commit
- This eliminates the frequent false-positive triggers from scheduled `ots-upgrade` runs that found nothing to do, reducing unnecessary workflow executions and improving CI efficiency

https://claude.ai/code/session_017M4GTSGwoErNRHfT9JudS3